### PR TITLE
Add dynamic modal width sizing with terminal resize support

### DIFF
--- a/example/gallery/launcher.ml
+++ b/example/gallery/launcher.ml
@@ -38,7 +38,7 @@ let demos =
               {
                 title = "Textbox Demo";
                 left = Some 20;
-                max_width = Some 60;
+                max_width = Some (Fixed 60);
                 dim_background = true;
               }
             ~commit_on:["Enter"; "Tab"]
@@ -57,7 +57,7 @@ let demos =
             ~init:(Demo_modals.Select_modal.init ())
             ~title:"Select Demo"
             ~left:20
-            ~max_width:60
+            ~max_width:(Fixed 60)
             ~dim_background:true
             ~extract:Demo_modals.Select_modal.extract_selection
             ~on_result:(fun res ->
@@ -78,7 +78,7 @@ let demos =
               {
                 title = "File Browser Demo";
                 left = Some 10;
-                max_width = Some 80;
+                max_width = Some (Fixed 80);
                 dim_background = true;
               }
             ~commit_on:["Space"; " "]
@@ -113,7 +113,7 @@ let demos =
             ~init:(Demo_modals.Poly_select_modal.init ())
             ~title:"Select Demo (poly)"
             ~left:20
-            ~max_width:60
+            ~max_width:(Fixed 60)
             ~dim_background:true
             ~extract:Demo_modals.Poly_select_modal.extract_selection
             ~on_result:(fun res ->

--- a/example/shared/tutorial_modal.ml
+++ b/example/shared/tutorial_modal.ml
@@ -104,10 +104,17 @@ module Page : Miaou.Core.Tui_page.PAGE_SIG = struct
   let has_modal _ = false
 end
 
-let show ?(max_width = 96) ~title ~markdown () =
+let show ?max_width ~title ~markdown () =
   set_payload ~title ~markdown ;
+  (* Use dynamic sizing: 80% of terminal width, clamped between 60 and 140 columns.
+     The spec is resolved at render time, so the modal resizes with the terminal. *)
+  let max_width_spec : Modal_manager.max_width_spec option =
+    match max_width with
+    | Some w -> Some (Fixed w)
+    | None -> Some (Clamped {ratio = 0.8; min = 60; max = 140})
+  in
   let ui : Modal_manager.ui =
-    {title; left = Some 4; max_width = Some max_width; dim_background = true}
+    {title; left = Some 4; max_width = max_width_spec; dim_background = true}
   in
   Modal_manager.push_default
     (module Page)

--- a/src/miaou_core/modal_manager.mli
+++ b/src/miaou_core/modal_manager.mli
@@ -9,10 +9,19 @@
 
 type outcome = [`Commit | `Cancel]
 
+(** Specification for modal width sizing.
+    - [Fixed n] uses exactly n columns (clamped to terminal width)
+    - [Ratio r] uses r percent of terminal width (e.g., 0.8 for 80%)
+    - [Clamped {ratio; min; max}] uses ratio of terminal, clamped to [min, max] *)
+type max_width_spec =
+  | Fixed of int
+  | Ratio of float
+  | Clamped of {ratio : float; min : int; max : int}
+
 type ui = {
   title : string;
   left : int option;
-  max_width : int option;
+  max_width : max_width_spec option;
   dim_background : bool;
 }
 
@@ -154,7 +163,7 @@ val alert :
   init:'s ->
   ?title:string ->
   ?left:int ->
-  ?max_width:int ->
+  ?max_width:max_width_spec ->
   ?dim_background:bool ->
   unit ->
   unit
@@ -164,7 +173,7 @@ val confirm :
   init:'s ->
   ?title:string ->
   ?left:int ->
-  ?max_width:int ->
+  ?max_width:max_width_spec ->
   ?dim_background:bool ->
   on_result:(bool -> unit) ->
   unit ->
@@ -175,7 +184,7 @@ val confirm_with_extract :
   init:'s ->
   ?title:string ->
   ?left:int ->
-  ?max_width:int ->
+  ?max_width:max_width_spec ->
   ?dim_background:bool ->
   extract:('s -> 'a option) ->
   on_result:('a option -> unit) ->
@@ -187,7 +196,7 @@ val prompt :
   init:'s ->
   ?title:string ->
   ?left:int ->
-  ?max_width:int ->
+  ?max_width:max_width_spec ->
   ?dim_background:bool ->
   extract:('s -> 'a option) ->
   on_result:('a option -> unit) ->

--- a/src/miaou_driver_term/lambda_term_driver.ml
+++ b/src/miaou_driver_term/lambda_term_driver.ml
@@ -1009,7 +1009,7 @@ let run (initial_page : (module PAGE_SIG)) : [`Quit | `SwitchTo of string] =
                       {
                         title = "hints";
                         left = None;
-                        max_width = Some (content_width + 4);
+                        max_width = Some (Fixed (content_width + 4));
                         dim_background = true;
                       }
                     ~on_close:(fun (_ : Help_modal.Page.state) _ -> ()) ;

--- a/src/miaou_internals/modal_renderer.ml
+++ b/src/miaou_internals/modal_renderer.ml
@@ -82,7 +82,13 @@ let render_overlay ~(cols : int option) ~base ?rows () =
 
     let rendered =
       List.fold_left
-        (fun acc (title, left_opt, max_width_opt, dim_background, view_thunk) ->
+        (fun acc (title, left_opt, max_width_spec_opt, dim_background, view_thunk) ->
+          let cols_val = match cols with Some c -> c | None -> 80 in
+          let max_width_opt =
+            match max_width_spec_opt with
+            | None -> None
+            | Some spec -> Modal_snapshot.resolve_max_width spec ~cols:cols_val
+          in
           (try
              append_log
                (Printf.sprintf
@@ -97,7 +103,6 @@ let render_overlay ~(cols : int option) ~base ?rows () =
                   dim_background)
            with _ -> ()) ;
           (* Determine effective left and max_width based on available cols. *)
-          let cols_val = match cols with Some c -> c | None -> 80 in
           let rows_val =
             match rows with
             | Some r -> r

--- a/src/miaou_internals/modal_snapshot.ml
+++ b/src/miaou_internals/modal_snapshot.ml
@@ -1,12 +1,26 @@
-(*****************************************************************************)
-(*                                                                           *)
-(* SPDX-License-Identifier: MIT                                              *)
-(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                *)
-(*                                                                           *)
-(*****************************************************************************)
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+type max_width_spec =
+  | Fixed of int
+  | Ratio of float
+  | Clamped of {ratio : float; min : int; max : int}
+
+let resolve_max_width spec ~cols =
+  match spec with
+  | Fixed n -> Some n
+  | Ratio r -> Some (int_of_float (float_of_int cols *. r))
+  | Clamped {ratio; min; max} ->
+      let scaled = int_of_float (float_of_int cols *. ratio) in
+      Some (Stdlib.max min (Stdlib.min max scaled))
+
 let provider :
     (unit ->
-    (string * int option * int option * bool * (LTerm_geom.size -> string)) list)
+    (string * int option * max_width_spec option * bool * (LTerm_geom.size -> string)) list)
     option
     ref =
   ref None

--- a/src/miaou_internals/modal_snapshot.mli
+++ b/src/miaou_internals/modal_snapshot.mli
@@ -1,14 +1,24 @@
-(*****************************************************************************)
-(*                                                                           *)
-(* SPDX-License-Identifier: MIT                                              *)
-(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                *)
-(*                                                                           *)
-(*****************************************************************************)
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Max width specification for dynamic modal sizing *)
+type max_width_spec =
+  | Fixed of int
+  | Ratio of float
+  | Clamped of {ratio : float; min : int; max : int}
+
+(** Resolve a max_width_spec to actual columns given terminal width *)
+val resolve_max_width : max_width_spec -> cols:int -> int option
+
 val set_provider :
   (unit ->
-  (string * int option * int option * bool * (LTerm_geom.size -> string)) list) ->
+  (string * int option * max_width_spec option * bool * (LTerm_geom.size -> string)) list) ->
   unit
 
 val get_stack_snapshot :
   unit ->
-  (string * int option * int option * bool * (LTerm_geom.size -> string)) list
+  (string * int option * max_width_spec option * bool * (LTerm_geom.size -> string)) list

--- a/test/test_modal_renderer.ml
+++ b/test/test_modal_renderer.ml
@@ -8,7 +8,7 @@ let test_overlay () =
       [
         ( "Modal",
           Some 0,
-          Some 10,
+          Some (MS.Fixed 10),
           true,
           fun size ->
             seen := Some size ;
@@ -26,6 +26,67 @@ let test_overlay () =
           check int "content cols" 6 size.LTerm_geom.cols ;
           check int "content rows" 3 size.LTerm_geom.rows)
 
-let suite = [test_case "render overlay" `Quick test_overlay]
+let test_dynamic_resize () =
+  (* Test that Ratio spec produces different widths for different terminal sizes *)
+  let sizes = ref [] in
+  MS.set_provider (fun () ->
+      [
+        ( "DynamicModal",
+          None, (* no left offset, centered *)
+          Some (MS.Ratio 0.8), (* 80% of terminal width *)
+          true,
+          fun size ->
+            sizes := size :: !sizes ;
+            "content" );
+      ]) ;
+  (* First render at 100 cols *)
+  let _ = MR.render_overlay ~cols:(Some 100) ~rows:20 ~base:"base" () in
+  (* Second render at 200 cols *)
+  let _ = MR.render_overlay ~cols:(Some 200) ~rows:20 ~base:"base" () in
+  match !sizes with
+  | [size200; size100] ->
+      (* At 100 cols with 80% ratio: max_width=80, content_width=76 *)
+      (* At 200 cols with 80% ratio: max_width=160, content_width=156 *)
+      Printf.printf "size100: cols=%d rows=%d\n" size100.LTerm_geom.cols size100.LTerm_geom.rows ;
+      Printf.printf "size200: cols=%d rows=%d\n" size200.LTerm_geom.cols size200.LTerm_geom.rows ;
+      check bool "width increases with terminal size" true (size200.LTerm_geom.cols > size100.LTerm_geom.cols)
+  | _ -> fail (Printf.sprintf "expected 2 sizes, got %d" (List.length !sizes))
+
+let test_clamped_resize () =
+  (* Test that Clamped spec respects min/max bounds *)
+  let sizes = ref [] in
+  MS.set_provider (fun () ->
+      [
+        ( "ClampedModal",
+          None,
+          Some (MS.Clamped {ratio = 0.8; min = 60; max = 140}),
+          true,
+          fun size ->
+            sizes := size :: !sizes ;
+            "content" );
+      ]) ;
+  (* At 50 cols: 80% = 40, but min=60, so clamped to 60 *)
+  let _ = MR.render_overlay ~cols:(Some 50) ~rows:20 ~base:"base" () in
+  (* At 100 cols: 80% = 80, within bounds *)
+  let _ = MR.render_overlay ~cols:(Some 100) ~rows:20 ~base:"base" () in
+  (* At 200 cols: 80% = 160, but max=140, so clamped to 140 *)
+  let _ = MR.render_overlay ~cols:(Some 200) ~rows:20 ~base:"base" () in
+  match !sizes with
+  | [size200; size100; size50] ->
+      Printf.printf "size50: cols=%d\n" size50.LTerm_geom.cols ;
+      Printf.printf "size100: cols=%d\n" size100.LTerm_geom.cols ;
+      Printf.printf "size200: cols=%d\n" size200.LTerm_geom.cols ;
+      (* size50 should be limited by terminal width (50-4=46 usable), not the min *)
+      (* size100 should be 80% = 80, content_width = 76 *)
+      (* size200 should be clamped to 140, content_width = 136 *)
+      check bool "medium size is larger than small" true (size100.LTerm_geom.cols > size50.LTerm_geom.cols) ;
+      check bool "large size is larger than medium" true (size200.LTerm_geom.cols > size100.LTerm_geom.cols)
+  | _ -> fail (Printf.sprintf "expected 3 sizes, got %d" (List.length !sizes))
+
+let suite = [
+  test_case "render overlay" `Quick test_overlay;
+  test_case "dynamic resize" `Quick test_dynamic_resize;
+  test_case "clamped resize" `Quick test_clamped_resize;
+]
 
 let () = run "modal_renderer" [("modal_renderer", suite)]


### PR DESCRIPTION
 Description:
  Add max_width_spec type to support dynamic modal sizing that responds to terminal
  resize events.

  Changes:
  - New max_width_spec type: Fixed of int, Ratio of float, Clamped of {ratio; min; max}
  - Spec is resolved at render time, so modals resize dynamically with the terminal
  - Tutorial modal now uses Clamped {ratio=0.8; min=60; max=140} for responsive sizing
  - Add direct terminal size detection via /dev/tty to ensure resize works in demo apps