### PR TITLE
fix(packages): move miaou.lib to miaou-core for terminal-only access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,14 @@ Restructured opam packages to allow terminal-only builds without SDL2 dependency
 - **`miaou-runner`**: Runner with `miaou-driver-sdl` as optional dependency
 - **`miaou-tui`**: Meta-package for terminal-only installs (no SDL)
 - **`miaou`**: Meta-package for full install (includes SDL)
+- **`miaou-core.lib`**: The convenience `Miaou` module (re-exporting Core, Widgets, etc.) is now part of `miaou-core`, available to terminal-only users
 
 Terminal-only users can now: `opam install miaou-tui`
 
 ### Breaking Changes (2025-12-17)
 
 - Library public names changed to use package prefixes:
+  - `miaou.lib` → `miaou-core.lib`
   - `miaou.core` → `miaou-core.core`
   - `miaou.widgets.display` → `miaou-core.widgets.display`
   - `miaou.driver.term` → `miaou-driver-term.driver`

--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,7 @@
 
 (library
  (name miaou)
- (public_name miaou.lib)
+ (public_name miaou-core.lib)
  (modules miaou net cohttp_net)
  (instrumentation
   (backend bisect_ppx))


### PR DESCRIPTION
The Miaou convenience module (re-exporting Core, Widgets, etc.) should be available to terminal-only users. Moved from miaou.lib to miaou-core.lib since it doesn't use SDL.