### PR TITLE
fix(ci): add apt-get update before installing SDL dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Update apt cache
+        run: sudo apt-get update
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.3.0


### PR DESCRIPTION
Fix stale apt cache causing 404 errors when installing libsdl2-dev and related packages on GitHub Actions runners.