### PR TITLE
perf(driver): cache terminal size detection

### DIFF
--- a/src/miaou_driver_term/lambda_term_driver.ml
+++ b/src/miaou_driver_term/lambda_term_driver.ml
@@ -66,7 +66,9 @@ let run (initial_page : (module PAGE_SIG)) : [`Quit | `SwitchTo of string] =
            let sigwinch = 28 in
            Sys.set_signal
              sigwinch
-             (Sys.Signal_handle (fun _ -> Atomic.set resize_pending true))
+             (Sys.Signal_handle (fun _ ->
+                  Term_size_detection.invalidate_cache () ;
+                  Atomic.set resize_pending true))
          with _ -> ()) ;
 
         (* Cache the last rendered frame to avoid unnecessary redraws (reduces flicker). *)

--- a/src/miaou_driver_term/term_size_detection.mli
+++ b/src/miaou_driver_term/term_size_detection.mli
@@ -11,5 +11,11 @@
     3. stty size
     4. tput
     5. stty -a parsing
-    Falls back to 24x80 if all methods fail. *)
+    Falls back to 24x80 if all methods fail.
+
+    Results are cached to avoid spawning subprocesses on every render.
+    Call [invalidate_cache] on SIGWINCH to pick up terminal resize. *)
 val detect_size : unit -> LTerm_geom.size
+
+(** Invalidate the cached terminal size. Call this on SIGWINCH. *)
+val invalidate_cache : unit -> unit


### PR DESCRIPTION
Cache stty/tput subprocess results to avoid spawning on every render. Invalidate cache on SIGWINCH to detect terminal resize.

