### PR TITLE
docs: update architecture description and add input drain to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab completion always includes hidden files for convenience (allows completing `.config/` etc.)
 - Header hint updates dynamically to show current state
 
+#### Textbox Input Draining for Typing Responsiveness
+
+- **`Miaou_helpers.Input_drain`** module for draining buffered input characters
+- Textbox widgets now process all pending printable characters at once
+- Prevents typing lag when entering text quickly
+- Driver registers drain function, widgets call `drain_pending_chars()`
+
 ### Added (2025-12-17)
 
 - Modal sizing supports dynamic width specs (`Fixed`, `Ratio`, `Clamped`) resolved at render time, including fallback terminal size detection via `/dev/tty` so modals resize with the terminal even when `System` is mocked.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 🐱 MIAOU
 
-MIAOU is a playful TUI library for OCaml built on the Model–View–Update (MVU) pattern.
+MIAOU is a playful TUI library for OCaml with a state-view-handlers architecture.
 
 Why the name?
 
-It’s an acronym: Model, Interface, Application, OCaml, Update.
+It's an acronym: Model, Interface, Application, OCaml, UI.
 
 It’s also the French way of writing a cat’s meow—a nod to OCaml’s French roots.
 
@@ -22,7 +22,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution guidelines and [SECURI
 
 Features at a glance
 --------------------
-- MVU-inspired page lifecycle with modal support and capability injection
+- State-view-handlers page lifecycle with modal support and capability injection
 - Ready-to-use widgets: tables, file browsers, pagers, modal forms, panes, text boxes, palette helpers, charts (sparkline, line, bar), image viewer, QR code generator, etc.
 - Lambda-Term driver plus an experimental SDL2 driver with enhanced graphics rendering
 - Headless driver for tests/CI

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ This document describes the core architecture of MIAOU, a terminal/SDL UI framew
 
 ## Overview
 
-MIAOU follows the **Model-View-Update (MVU)** pattern, similar to Elm. Applications are built from:
+MIAOU uses a **state-view-handlers** architecture. Each page has immutable state, a pure view function, and key handlers that return new state. Applications are built from:
 
 - **Pages** - Self-contained UI screens with state and rendering
 - **Widgets** - Reusable UI components (buttons, tables, charts, etc.)


### PR DESCRIPTION
- README.md: Update from MVU to state-view-handlers terminology
- docs/architecture.md: Update overview description
- CHANGELOG.md: Add textbox input draining feature entry
