### PR TITLE
fix(runner): add missing miaou-driver-matrix dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -81,7 +81,7 @@
  (authors "Nomadic Labs <contact@nomadic-labs.com>")
  (homepage "https://github.com/trilitech/miaou")
  (bug_reports "https://github.com/trilitech/miaou/issues")
- (depends miaou-core miaou-driver-term)
+ (depends miaou-core miaou-driver-term miaou-driver-matrix)
  (depopts miaou-driver-sdl))
 
 (package

--- a/miaou-runner.opam
+++ b/miaou-runner.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "3.15"}
   "miaou-core"
   "miaou-driver-term"
+  "miaou-driver-matrix"
   "odoc" {with-doc}
 ]
 depopts: ["miaou-driver-sdl"]


### PR DESCRIPTION
This pull request adds a new dependency on the `miaou-driver-matrix` package to both the `dune-project` and `miaou-runner.opam` files. This ensures that the project will now require `miaou-driver-matrix` to build and run.

Dependency updates:

* Added `miaou-driver-matrix` to the dependencies in `dune-project` to ensure it is included during the build process.
* Added `miaou-driver-matrix` to the `depends` list in `miaou-runner.opam` so that it is installed as a required package.