### PR TITLE
File browser: separate selection from Enter

### DIFF
--- a/src/miaou_core/file_browser_modal.ml
+++ b/src/miaou_core/file_browser_modal.ml
@@ -90,7 +90,7 @@ let open_modal ?(title = "Select path") ?path ?dirs_only ?require_writable
         Modal_manager.close_top `Cancel ;
         ps')
       else
-        match File_browser_widget.get_selection browser' with
+        match File_browser_widget.get_pending_selection browser' with
         | Some path ->
             on_select path ;
             Modal_manager.close_top `Commit ;

--- a/src/miaou_widgets_layout/file_browser_widget.mli
+++ b/src/miaou_widgets_layout/file_browser_widget.mli
@@ -107,6 +107,10 @@ val reset_cancelled : t -> t
 (** Get the current directory path. *)
 val get_current_path : t -> string
 
+(** Pending selection set by explicit confirm actions (e.g., space or path entry).
+    Use this to decide whether to commit the selection (e.g., in a modal). *)
+val get_pending_selection : t -> string option
+
 (** Get the selected path.
 
     Returns [Some path] if a valid directory is selected and passes filters


### PR DESCRIPTION
## Summary
- keep current-dir entry first but treat Enter as navigation only (no auto commit)
- add explicit pending selection via Space/path entry and expose getter
- modal commits only when a pending selection exists; update hints accordingly

## Testing
- dune build
- dune runtest