### PR TITLE
Fix file browser Enter navigation and demo modal

### DIFF
--- a/example/modals/file_browser_modal.ml
+++ b/example/modals/file_browser_modal.ml
@@ -28,13 +28,11 @@ let handle_key ps key_str ~size:_ =
   Miaou.Core.Navigation.update
     (fun s ->
       let s' = FB.handle_key s ~key:key_str in
-      if key_str = "Enter" then
-        match FB.get_selected_entry s' with
-        | Some e when (not e.is_dir) || e.name = "." ->
-            Miaou.Core.Modal_manager.close_top `Commit ;
-            s'
-        | _ -> s'
-      else s')
+      match FB.get_pending_selection s' with
+      | Some _ ->
+          Miaou.Core.Modal_manager.close_top `Commit ;
+          s'
+      | None -> s')
     ps
 
 let move ps _ = ps


### PR DESCRIPTION
Fixes an issue where pressing Enter on a directory in the file browser would select it instead of navigating into it.

Changes:
- Added fallback in `File_browser_widget`: if `is_directory` check fails (or returns false), verify if the path is browseable by attempting to list entries. If successful, treat as directory.
- Updated `example/modals/file_browser_modal.ml` to use `get_pending_selection` instead of aggressively committing on Enter key press. This ensures the demo respects the widget's internal navigation logic.