### PR TITLE
fix(matrix): force refresh on modal close to prevent artifacts

### DIFF
--- a/src/miaou_driver_matrix/matrix_driver.ml
+++ b/src/miaou_driver_matrix/matrix_driver.ml
@@ -249,9 +249,9 @@ let run (initial_page : (module Tui_page.PAGE_SIG)) :
                 ~cols
                 ops) ;
 
-        (* On modal OPEN, do synchronous clear+render to avoid overlay artifacts.
-           On modal CLOSE, just let diff handle it - no clear needed. *)
-        if modal_just_changed && modal_active then begin
+        (* On modal state change (open OR close), do synchronous clear+render.
+           This prevents artifacts when modal closes and underlying content has changed. *)
+        if modal_just_changed then begin
           Matrix_buffer.mark_all_dirty buffer ;
           Matrix_terminal.write terminal "\027[2J\027[H" ;
           Matrix_render_loop.force_render render_loop


### PR DESCRIPTION
## Summary
- When a modal closes and the underlying content has changed (e.g., after deleting an item), the diff alone may not properly handle both the modal overlay disappearing and the content change
- This can cause visual artifacts mixing pre/post change rendering
- Force a full clear+render on any modal state change (open OR close), not just on open

## Test plan
- [ ] Open a modal, make a change that affects underlying content, close modal
- [ ] Verify no rendering artifacts appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)