### PR TITLE
feat: add enable_mouse parameter to Runner_tui.run

### DIFF
--- a/src/miaou_runner/runner_tui.ml
+++ b/src/miaou_runner/runner_tui.ml
@@ -1,4 +1,4 @@
-let run page =
+let run ?(enable_mouse = true) page =
   let term_backend =
     {
       Miaou_runner_common.Tui_driver_common.available =
@@ -12,11 +12,18 @@ let run page =
       run = (fun _ -> `Quit);
     }
   in
+  let matrix_config =
+    if enable_mouse then None
+    else
+      Some
+        (Miaou_driver_matrix.Matrix_config.load ()
+        |> Miaou_driver_matrix.Matrix_config.with_mouse_disabled)
+  in
   let matrix_backend =
     {
       Miaou_runner_common.Tui_driver_common.available =
         Miaou_driver_matrix.Matrix_driver.available;
-      run = Miaou_driver_matrix.Matrix_driver.run;
+      run = Miaou_driver_matrix.Matrix_driver.run ~config:matrix_config;
     }
   in
   Miaou_runner_common.Tui_driver_common.run


### PR DESCRIPTION
Add a simple `~enable_mouse` parameter (default: true) to allow applications to disable mouse tracking.

This provides a clean API without exposing internal Matrix_config details.

**Usage:**
```ocaml
Runner_tui.run ~enable_mouse:false my_page
```

**Rationale:**
Mouse tracking interferes with traditional terminal copy/paste operations. This parameter allows applications to opt-out when needed.