### PR TITLE
feat: add Grid_layout module and Flex_layout constraints

### DIFF
--- a/example/demos/grid_layout/README.md
+++ b/example/demos/grid_layout/README.md
@@ -1,0 +1,36 @@
+# Grid Layout
+
+A CSS Grid-style 2D layout engine.
+
+## Track types
+
+- `Px n` — fixed size in cells
+- `Fr f` — fractional unit, shares remaining space proportionally
+- `Percent p` — percentage of total available space
+- `Auto` — equal share of remaining space (same as `Fr 1.`)
+- `MinMax (min, max)` — clamped between min and max
+
+## Placement
+
+Place children at `(row, col)` with optional row/column spans.
+
+```ocaml
+let grid = Grid_layout.create
+  ~rows:[Px 3; Fr 1.; Px 1]
+  ~cols:[Px 20; Fr 1.]
+  ~col_gap:1
+  [
+    span ~row:0 ~col:0 ~row_span:1 ~col_span:2 render_header;
+    cell ~row:1 ~col:0 render_sidebar;
+    cell ~row:1 ~col:1 render_main;
+    span ~row:2 ~col:0 ~row_span:1 ~col_span:2 render_footer;
+  ]
+```
+
+## Features
+
+- Row and column gaps
+- Padding around container
+- Cell spanning (row_span, col_span)
+- Fractional and percentage track sizing
+- MinMax clamped tracks

--- a/example/demos/grid_layout/dune
+++ b/example/demos/grid_layout/dune
@@ -1,0 +1,15 @@
+(library
+ (name grid_layout_demo)
+ (modules page)
+ (preprocess
+  (pps ppx_blob))
+ (preprocessor_deps
+  (file README.md))
+ (libraries demo_shared miaou miaou-core.lib_miaou_internal))
+
+(executable
+ (name main)
+ (public_name miaou.grid_layout-demo)
+ (package miaou)
+ (modules main)
+ (libraries grid_layout_demo miaou-runner.tui miaou-core.helpers eio_main))

--- a/example/demos/grid_layout/main.ml
+++ b/example/demos/grid_layout/main.ml
@@ -1,0 +1,17 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+let () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  Miaou_helpers.Fiber_runtime.init ~env ~sw ;
+  Demo_shared.Demo_config.register_mocks () ;
+  Demo_shared.Demo_config.ensure_system_capability () ;
+  let page : Miaou.Core.Registry.page =
+    (module Grid_layout_demo.Page : Miaou.Core.Tui_page.PAGE_SIG)
+  in
+  ignore (Miaou_runner_tui.Runner_tui.run page)

--- a/example/demos/grid_layout/page.ml
+++ b/example/demos/grid_layout/page.ml
@@ -1,0 +1,87 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+module Inner = struct
+  let tutorial_title = "Grid Layout"
+
+  let tutorial_markdown = [%blob "README.md"]
+
+  module Grid = Miaou_widgets_layout.Grid_layout
+  module W = Miaou_widgets_display.Widgets
+
+  type state = {next_page : string option}
+
+  type msg = unit
+
+  let init () = {next_page = None}
+
+  let render_cell label ~size =
+    let header = W.titleize label in
+    let info =
+      W.dim (Printf.sprintf "%dx%d" size.LTerm_geom.cols size.LTerm_geom.rows)
+    in
+    String.concat "\n" [header; info]
+
+  let update s _ = s
+
+  let view _ ~focus:_ ~size =
+    let header = W.titleize "Grid Layout (Esc returns, t opens tutorial)" in
+    let desc =
+      W.dim
+        "Header spanning 2 cols | Sidebar (fixed 20) + Main (Fr 1.) | Footer \
+         spanning 2 cols"
+    in
+    let grid_h = max 8 (size.LTerm_geom.rows - 5) in
+    let grid_size = {LTerm_geom.cols = size.LTerm_geom.cols; rows = grid_h} in
+    let grid =
+      Grid.create
+        ~rows:[Grid.Px 3; Grid.Fr 1.; Grid.Px 1]
+        ~cols:[Grid.Px 20; Grid.Fr 1.]
+        ~col_gap:1
+        [
+          Grid.span ~row:0 ~col:0 ~row_span:1 ~col_span:2 (render_cell "Header");
+          Grid.cell ~row:1 ~col:0 (render_cell "Sidebar");
+          Grid.cell ~row:1 ~col:1 (render_cell "Main");
+          Grid.span ~row:2 ~col:0 ~row_span:1 ~col_span:2 (render_cell "Footer");
+        ]
+    in
+    let grid_block = Grid.render grid ~size:grid_size in
+    String.concat "\n\n" [header; desc; grid_block]
+
+  let go_back = {next_page = Some Demo_shared.Demo_config.launcher_page_name}
+
+  let handle_key s key_str ~size:_ =
+    match Miaou.Core.Keys.of_string key_str with
+    | Some (Miaou.Core.Keys.Char "Esc") | Some (Miaou.Core.Keys.Char "Escape")
+      ->
+        go_back
+    | _ -> s
+
+  let move s _ = s
+
+  let refresh s = s
+
+  let enter s = s
+
+  let service_select s _ = s
+
+  let service_cycle s _ = s
+
+  let handle_modal_key s _ ~size:_ = s
+
+  let next_page s = s.next_page
+
+  let keymap (_ : state) = []
+
+  let handled_keys () = []
+
+  let back _ = go_back
+
+  let has_modal _ = false
+end
+
+include Demo_shared.Demo_page.Make (Inner)

--- a/example/gallery/dune
+++ b/example/gallery/dune
@@ -22,6 +22,7 @@
   tabs_demo
   toast_demo
   flex_layout_demo
+  grid_layout_demo
   description_list_demo
   spinner_progress_demo
   line_chart_demo

--- a/example/gallery/launcher.ml
+++ b/example/gallery/launcher.ml
@@ -197,6 +197,13 @@ let demos =
           (module Flex_layout_demo.Page : Miaou.Core.Tui_page.PAGE_SIG);
     };
     {
+      title = "Grid Layout";
+      open_demo =
+        goto
+          "demo_grid"
+          (module Grid_layout_demo.Page : Miaou.Core.Tui_page.PAGE_SIG);
+    };
+    {
       title = "Link";
       open_demo =
         goto "demo_link" (module Link_demo.Page : Miaou.Core.Tui_page.PAGE_SIG);

--- a/src/miaou_widgets_layout/dune
+++ b/src/miaou_widgets_layout/dune
@@ -14,6 +14,7 @@
   card_widget
   sidebar_widget
   flex_layout
+  grid_layout
   toast_widget)
  (instrumentation
   (backend bisect_ppx))

--- a/src/miaou_widgets_layout/flex_layout.mli
+++ b/src/miaou_widgets_layout/flex_layout.mli
@@ -29,6 +29,12 @@ type child = {
       (** Optional cross-axis size hint; [None] uses the parent slot. *)
 }
 
+type child_constraint = {
+  index : int;  (** 0-based child index. *)
+  min_size : int option;  (** Minimum main-axis size in cells. *)
+  max_size : int option;  (** Maximum main-axis size in cells. *)
+}
+
 type t
 
 (** Create a flex container.
@@ -38,6 +44,7 @@ type t
     - [justify]: distribution on the main axis (start/center/end/space_between/space_around).
     - [gap]: horizontal/vertical spacing between children.
     - [padding]: surrounding padding inside the container.
+    - [constraints]: optional per-child min/max size constraints (by index).
 
     Children are rendered in order; strings longer than their slot are visually truncated. *)
 val create :
@@ -46,6 +53,7 @@ val create :
   ?justify:justify ->
   ?gap:spacing ->
   ?padding:padding ->
+  ?constraints:child_constraint list ->
   child list ->
   t
 

--- a/src/miaou_widgets_layout/grid_layout.ml
+++ b/src/miaou_widgets_layout/grid_layout.ml
@@ -1,0 +1,250 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* SPDX-License-Identifier: MIT                                              *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+module W = Miaou_widgets_display.Widgets
+module Helpers = Miaou_helpers.Helpers
+
+type track =
+  | Px of int
+  | Fr of float
+  | Percent of float
+  | Auto
+  | MinMax of int * int
+
+type placement = {row : int; col : int; row_span : int; col_span : int}
+
+type grid_child = {
+  render : size:LTerm_geom.size -> string;
+  placement : placement;
+}
+
+type t = {
+  rows : track list;
+  cols : track list;
+  row_gap : int;
+  col_gap : int;
+  padding : Flex_layout.padding;
+  children : grid_child list;
+}
+
+let default_padding : Flex_layout.padding =
+  {left = 0; right = 0; top = 0; bottom = 0}
+
+let create ~rows ~cols ?(row_gap = 0) ?(col_gap = 0)
+    ?(padding = default_padding) children =
+  {rows; cols; row_gap; col_gap; padding; children}
+
+let cell ~row ~col render =
+  {render; placement = {row; col; row_span = 1; col_span = 1}}
+
+let span ~row ~col ~row_span ~col_span render =
+  {render; placement = {row; col; row_span; col_span}}
+
+(* Resolve track sizes to concrete pixel values. *)
+let resolve_tracks tracks available =
+  let n = List.length tracks in
+  let sizes = Array.make n 0 in
+  let used = ref 0 in
+  (* Pass 1: fixed, percent, minmax base *)
+  List.iteri
+    (fun i t ->
+      match t with
+      | Px p ->
+          let v = max 0 p in
+          sizes.(i) <- v ;
+          used := !used + v
+      | Percent p ->
+          let v = max 0 (int_of_float (p /. 100. *. float available)) in
+          sizes.(i) <- v ;
+          used := !used + v
+      | MinMax (mn, _) ->
+          let v = max 0 mn in
+          sizes.(i) <- v ;
+          used := !used + v
+      | Fr _ | Auto -> ())
+    tracks ;
+  (* Pass 2: distribute remaining to Fr/Auto *)
+  let remaining = max 0 (available - !used) in
+  let total_fr =
+    List.fold_left
+      (fun acc t ->
+        match t with Fr f -> acc +. f | Auto -> acc +. 1. | _ -> acc)
+      0.
+      tracks
+  in
+  if total_fr > 0. then
+    List.iteri
+      (fun i t ->
+        match t with
+        | Fr f ->
+            sizes.(i) <- max 0 (int_of_float (f /. total_fr *. float remaining))
+        | Auto ->
+            sizes.(i) <-
+              max 0 (int_of_float (1. /. total_fr *. float remaining))
+        | _ -> ())
+      tracks ;
+  (* Pass 3: give leftover to MinMax up to their max *)
+  let total_used = Array.fold_left ( + ) 0 sizes in
+  let leftover = ref (max 0 (available - total_used)) in
+  if !leftover > 0 then
+    List.iteri
+      (fun i t ->
+        match t with
+        | MinMax (_, mx) ->
+            let room = max 0 (mx - sizes.(i)) in
+            let give = min room !leftover in
+            sizes.(i) <- sizes.(i) + give ;
+            leftover := !leftover - give
+        | _ -> ())
+      tracks ;
+  sizes
+
+let split_lines s = String.split_on_char '\n' s
+
+let truncate_visible s width =
+  let idx = Helpers.visible_byte_index_of_pos s width in
+  String.sub s 0 idx
+
+let pad_line line width =
+  let vis = W.visible_chars_count line in
+  if vis >= width then truncate_visible line width
+  else line ^ String.make (width - vis) ' '
+
+let pad_block lines ~width ~height =
+  let padded = List.map (fun l -> pad_line l width) lines in
+  let len = List.length padded in
+  if len >= height then List.filteri (fun i _ -> i < height) padded
+  else padded @ List.init (height - len) (fun _ -> String.make width ' ')
+
+(* Compute the pixel width of a column span including inner gaps. *)
+let span_width col_sizes col_gap start count =
+  let w = ref 0 in
+  for c = start to start + count - 1 do
+    w := !w + col_sizes.(c)
+  done ;
+  !w + max 0 ((count - 1) * col_gap)
+
+(* Compute the pixel height of a row span including inner gaps. *)
+let span_height row_sizes row_gap start count =
+  let h = ref 0 in
+  for r = start to start + count - 1 do
+    h := !h + row_sizes.(r)
+  done ;
+  !h + max 0 ((count - 1) * row_gap)
+
+let render t ~size =
+  let inner_w = size.LTerm_geom.cols - t.padding.left - t.padding.right in
+  let inner_h = size.LTerm_geom.rows - t.padding.top - t.padding.bottom in
+  let n_rows = List.length t.rows in
+  let n_cols = List.length t.cols in
+  if n_rows = 0 || n_cols = 0 then ""
+  else
+    let col_gap_total = max 0 ((n_cols - 1) * t.col_gap) in
+    let row_gap_total = max 0 ((n_rows - 1) * t.row_gap) in
+    let col_sizes = resolve_tracks t.cols (max 0 (inner_w - col_gap_total)) in
+    let row_sizes = resolve_tracks t.rows (max 0 (inner_h - row_gap_total)) in
+    (* Pre-render all children into blocks of lines. *)
+    let rendered =
+      List.filter_map
+        (fun child ->
+          let p = child.placement in
+          if p.row < 0 || p.row >= n_rows || p.col < 0 || p.col >= n_cols then
+            None
+          else
+            let rs = min p.row_span (n_rows - p.row) in
+            let cs = min p.col_span (n_cols - p.col) in
+            let w = span_width col_sizes t.col_gap p.col cs in
+            let h = span_height row_sizes t.row_gap p.row rs in
+            let child_size = {LTerm_geom.rows = max 0 h; cols = max 0 w} in
+            let lines = split_lines (child.render ~size:child_size) in
+            let block = pad_block lines ~width:w ~height:h in
+            Some (p, cs, rs, block))
+        t.children
+    in
+    (* Build a "covered" map: for each cell, which rendered child covers it
+     and what is the column offset within the span. *)
+    let owner = Array.init n_rows (fun _ -> Array.make n_cols None) in
+    List.iter
+      (fun (p, cs, rs, block) ->
+        for r = p.row to p.row + rs - 1 do
+          for c = p.col to p.col + cs - 1 do
+            owner.(r).(c) <- Some (p, cs, block)
+          done
+        done)
+      rendered ;
+    (* Assemble output line by line. *)
+    let buf = Buffer.create (inner_w * inner_h) in
+    let left_pad = String.make t.padding.left ' ' in
+    let blank_line = String.make inner_w ' ' in
+    (* Top padding *)
+    for _ = 1 to t.padding.top do
+      Buffer.add_string buf left_pad ;
+      Buffer.add_string buf blank_line ;
+      Buffer.add_char buf '\n'
+    done ;
+    (* For each grid row *)
+    for row = 0 to n_rows - 1 do
+      let row_h = row_sizes.(row) in
+      (* line offset within this grid row's portion of spanning blocks *)
+      let row_line_offset =
+        let off = ref 0 in
+        (* lines consumed by prior rows in a row-spanning block are accounted
+         for by computing the offset from the placement start row. *)
+        off := 0 ;
+        !off
+      in
+      ignore row_line_offset ;
+      for line_idx = 0 to row_h - 1 do
+        Buffer.add_string buf left_pad ;
+        let col = ref 0 in
+        while !col < n_cols do
+          if !col > 0 then Buffer.add_string buf (String.make t.col_gap ' ') ;
+          match owner.(row).(!col) with
+          | None ->
+              Buffer.add_string buf (String.make col_sizes.(!col) ' ') ;
+              incr col
+          | Some (p, cs, block) ->
+              if !col = p.col then begin
+                (* This is the start column of the span — output the full
+                 span width from the pre-rendered block. *)
+                let abs_line =
+                  let off = ref 0 in
+                  for r = p.row to row - 1 do
+                    off := !off + row_sizes.(r) + t.row_gap
+                  done ;
+                  !off + line_idx
+                in
+                let line =
+                  match List.nth_opt block abs_line with
+                  | Some l -> l
+                  | None ->
+                      String.make (span_width col_sizes t.col_gap p.col cs) ' '
+                in
+                Buffer.add_string buf line ;
+                col := !col + cs
+              end
+              else begin
+                (* We're inside a span but not at its start column. The start
+                 column already emitted the full span, so skip. However this
+                 should not happen because we jump col by cs above. If it
+                 does, emit blank. *)
+                Buffer.add_string buf (String.make col_sizes.(!col) ' ') ;
+                incr col
+              end
+        done ;
+        if row < n_rows - 1 || line_idx < row_h - 1 then
+          Buffer.add_char buf '\n'
+      done ;
+      (* Row gap *)
+      if row < n_rows - 1 then
+        for _ = 1 to t.row_gap do
+          Buffer.add_char buf '\n' ;
+          Buffer.add_string buf left_pad ;
+          Buffer.add_string buf blank_line
+        done
+    done ;
+    Buffer.contents buf

--- a/src/miaou_widgets_layout/grid_layout.mli
+++ b/src/miaou_widgets_layout/grid_layout.mli
@@ -1,0 +1,82 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* SPDX-License-Identifier: MIT                                              *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+(** CSS Grid-style 2D layout.
+
+    Define rows and columns with track sizes, place children into cells
+    (optionally spanning multiple rows/columns), and render the grid into
+    a newline-separated string.
+
+    {[
+    let grid = Grid_layout.create
+      ~rows:[Px 3; Fr 1.; Px 1]
+      ~cols:[Px 20; Fr 1.]
+      ~col_gap:1
+      [
+        span ~row:0 ~col:0 ~row_span:1 ~col_span:2 render_header;
+        cell ~row:1 ~col:0 render_sidebar;
+        cell ~row:1 ~col:1 render_main;
+        span ~row:2 ~col:0 ~row_span:1 ~col_span:2 render_footer;
+      ]
+    in
+    Grid_layout.render grid ~size
+    ]} *)
+
+(** Track sizing for rows and columns. *)
+type track =
+  | Px of int  (** Fixed size in cells. *)
+  | Fr of float  (** Fractional unit — shares remaining space proportionally. *)
+  | Percent of float  (** Percentage of total available space. *)
+  | Auto  (** Equal share of remaining space (same as [Fr 1.]). *)
+  | MinMax of int * int  (** Clamped: at least [min], at most [max]. *)
+
+(** Where a child sits in the grid. *)
+type placement = {
+  row : int;  (** 0-based row index. *)
+  col : int;  (** 0-based column index. *)
+  row_span : int;  (** Number of rows to span (default 1). *)
+  col_span : int;  (** Number of columns to span (default 1). *)
+}
+
+(** A child element placed in the grid. *)
+type grid_child = {
+  render : size:LTerm_geom.size -> string;
+  placement : placement;
+}
+
+type t
+
+(** Create a grid container.
+
+    @param rows Track definitions for each row.
+    @param cols Track definitions for each column.
+    @param row_gap Vertical gap between rows (default 0).
+    @param col_gap Horizontal gap between columns (default 0).
+    @param padding Surrounding padding inside the container. *)
+val create :
+  rows:track list ->
+  cols:track list ->
+  ?row_gap:int ->
+  ?col_gap:int ->
+  ?padding:Flex_layout.padding ->
+  grid_child list ->
+  t
+
+(** Render the grid into a newline-separated string sized to [size]. *)
+val render : t -> size:LTerm_geom.size -> string
+
+(** Place a child at [(row, col)] with span 1x1. *)
+val cell : row:int -> col:int -> (size:LTerm_geom.size -> string) -> grid_child
+
+(** Place a child with explicit row/column span. *)
+val span :
+  row:int ->
+  col:int ->
+  row_span:int ->
+  col_span:int ->
+  (size:LTerm_geom.size -> string) ->
+  grid_child

--- a/test/dune
+++ b/test/dune
@@ -197,6 +197,11 @@
  (libraries alcotest miaou-core.widgets.layout miaou-core.widgets.display))
 
 (test
+ (name test_grid_layout)
+ (modules test_grid_layout)
+ (libraries alcotest miaou-core.widgets.layout miaou-core.widgets.display))
+
+(test
  (name test_input_widgets)
  (modules test_input_widgets)
  (libraries

--- a/test/test_flex_layout.ml
+++ b/test/test_flex_layout.ml
@@ -110,6 +110,57 @@ let test_percent_ratio_allocation () =
   check int "percent child" 14 (count_char out 'B') ;
   check int "ratio child" 10 (count_char out 'C')
 
+let test_min_constraint () =
+  let make_child ch basis =
+    {
+      Flex.render = (fun ~size -> String.make size.LTerm_geom.cols ch);
+      basis;
+      cross = None;
+    }
+  in
+  let flex =
+    Flex.create
+      ~direction:Flex.Row
+      ~constraints:[{Flex.index = 0; min_size = Some 8; max_size = None}]
+      [make_child 'A' (Flex.Px 3); make_child 'B' Flex.Fill]
+  in
+  let out = Flex.render flex ~size:(size 20 1) in
+  check bool "min constraint applied" true (count_char out 'A' >= 8)
+
+let test_max_constraint () =
+  let make_child ch basis =
+    {
+      Flex.render = (fun ~size -> String.make size.LTerm_geom.cols ch);
+      basis;
+      cross = None;
+    }
+  in
+  let flex =
+    Flex.create
+      ~direction:Flex.Row
+      ~constraints:[{Flex.index = 0; min_size = None; max_size = Some 5}]
+      [make_child 'A' Flex.Fill; make_child 'B' Flex.Fill]
+  in
+  let out = Flex.render flex ~size:(size 20 1) in
+  check bool "max constraint applied" true (count_char out 'A' <= 5)
+
+let test_no_constraints_unchanged () =
+  let make_child ch basis =
+    {
+      Flex.render = (fun ~size -> String.make size.LTerm_geom.cols ch);
+      basis;
+      cross = None;
+    }
+  in
+  let flex =
+    Flex.create
+      ~direction:Flex.Row
+      [make_child 'A' Flex.Fill; make_child 'B' Flex.Fill]
+  in
+  let out = Flex.render flex ~size:(size 20 1) in
+  check int "A fills half" 10 (count_char out 'A') ;
+  check int "B fills half" 10 (count_char out 'B')
+
 let () =
   run
     "flex_layout"
@@ -121,5 +172,11 @@ let () =
           test_case "justify center" `Quick test_justify_center;
           test_case "align center column" `Quick test_align_center_column;
           test_case "percent + ratio alloc" `Quick test_percent_ratio_allocation;
+          test_case "min constraint" `Quick test_min_constraint;
+          test_case "max constraint" `Quick test_max_constraint;
+          test_case
+            "no constraints unchanged"
+            `Quick
+            test_no_constraints_unchanged;
         ] );
     ]

--- a/test/test_grid_layout.ml
+++ b/test/test_grid_layout.ml
@@ -1,0 +1,161 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+open Alcotest
+module Grid = Miaou_widgets_layout.Grid_layout
+
+let size cols rows = {LTerm_geom.cols; rows}
+
+let count_char s ch =
+  String.fold_left (fun acc c -> if Char.equal c ch then acc + 1 else acc) 0 s
+
+let fill_char ch ~size =
+  let lines =
+    List.init size.LTerm_geom.rows (fun _ ->
+        String.make size.LTerm_geom.cols ch)
+  in
+  String.concat "\n" lines
+
+let test_single_cell () =
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 2]
+      ~cols:[Grid.Px 5]
+      [Grid.cell ~row:0 ~col:0 (fill_char 'A')]
+  in
+  let out = Grid.render grid ~size:(size 5 2) in
+  let lines = String.split_on_char '\n' out in
+  check int "line count" 2 (List.length lines) ;
+  check int "A count" 10 (count_char out 'A')
+
+let test_two_columns () =
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 1]
+      ~cols:[Grid.Px 3; Grid.Px 3]
+      [
+        Grid.cell ~row:0 ~col:0 (fill_char 'A');
+        Grid.cell ~row:0 ~col:1 (fill_char 'B');
+      ]
+  in
+  let out = Grid.render grid ~size:(size 6 1) in
+  check int "A count" 3 (count_char out 'A') ;
+  check int "B count" 3 (count_char out 'B')
+
+let test_col_gap () =
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 1]
+      ~cols:[Grid.Px 3; Grid.Px 3]
+      ~col_gap:2
+      [
+        Grid.cell ~row:0 ~col:0 (fill_char 'A');
+        Grid.cell ~row:0 ~col:1 (fill_char 'B');
+      ]
+  in
+  let out = Grid.render grid ~size:(size 8 1) in
+  check int "A count" 3 (count_char out 'A') ;
+  check int "B count" 3 (count_char out 'B') ;
+  check int "space count" 2 (count_char out ' ')
+
+let test_fr_tracks () =
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 1]
+      ~cols:[Grid.Fr 1.; Grid.Fr 1.]
+      [
+        Grid.cell ~row:0 ~col:0 (fill_char 'A');
+        Grid.cell ~row:0 ~col:1 (fill_char 'B');
+      ]
+  in
+  let out = Grid.render grid ~size:(size 10 1) in
+  check int "A count" 5 (count_char out 'A') ;
+  check int "B count" 5 (count_char out 'B')
+
+let test_percent_track () =
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 1]
+      ~cols:[Grid.Percent 50.; Grid.Percent 50.]
+      [
+        Grid.cell ~row:0 ~col:0 (fill_char 'A');
+        Grid.cell ~row:0 ~col:1 (fill_char 'B');
+      ]
+  in
+  let out = Grid.render grid ~size:(size 20 1) in
+  check int "A count" 10 (count_char out 'A') ;
+  check int "B count" 10 (count_char out 'B')
+
+let test_column_span () =
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 1; Grid.Px 1]
+      ~cols:[Grid.Px 5; Grid.Px 5]
+      [
+        Grid.span ~row:0 ~col:0 ~row_span:1 ~col_span:2 (fill_char 'H');
+        Grid.cell ~row:1 ~col:0 (fill_char 'A');
+        Grid.cell ~row:1 ~col:1 (fill_char 'B');
+      ]
+  in
+  let out = Grid.render grid ~size:(size 10 2) in
+  check int "H count" 10 (count_char out 'H') ;
+  check int "A count" 5 (count_char out 'A') ;
+  check int "B count" 5 (count_char out 'B')
+
+let test_row_span () =
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 2; Grid.Px 2]
+      ~cols:[Grid.Px 3; Grid.Px 3]
+      [
+        Grid.span ~row:0 ~col:0 ~row_span:2 ~col_span:1 (fill_char 'S');
+        Grid.cell ~row:0 ~col:1 (fill_char 'A');
+        Grid.cell ~row:1 ~col:1 (fill_char 'B');
+      ]
+  in
+  let out = Grid.render grid ~size:(size 6 4) in
+  let lines = String.split_on_char '\n' out in
+  check int "line count" 4 (List.length lines) ;
+  check int "S count" 12 (count_char out 'S')
+
+let test_empty_grid () =
+  let grid = Grid.create ~rows:[] ~cols:[] [] in
+  let out = Grid.render grid ~size:(size 10 5) in
+  check string "empty" "" out
+
+let test_minmax_track () =
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 1]
+      ~cols:[Grid.MinMax (3, 8); Grid.Fr 1.]
+      [
+        Grid.cell ~row:0 ~col:0 (fill_char 'A');
+        Grid.cell ~row:0 ~col:1 (fill_char 'B');
+      ]
+  in
+  let out = Grid.render grid ~size:(size 20 1) in
+  let a_count = count_char out 'A' in
+  check bool "minmax at least 3" true (a_count >= 3) ;
+  check bool "minmax at most 8" true (a_count <= 8)
+
+let () =
+  run
+    "grid_layout"
+    [
+      ( "grid_layout",
+        [
+          test_case "single cell" `Quick test_single_cell;
+          test_case "two columns" `Quick test_two_columns;
+          test_case "column gap" `Quick test_col_gap;
+          test_case "fr tracks" `Quick test_fr_tracks;
+          test_case "percent track" `Quick test_percent_track;
+          test_case "column span" `Quick test_column_span;
+          test_case "row span" `Quick test_row_span;
+          test_case "empty grid" `Quick test_empty_grid;
+          test_case "minmax track" `Quick test_minmax_track;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- **Grid_layout** — new CSS Grid-style 2D layout engine with track sizing (`Px`, `Fr`, `Percent`, `Auto`, `MinMax`), cell placement with row/column spans, gaps, and padding
- **Flex_layout constraints** — add optional `?constraints` parameter to `Flex_layout.create` for per-child min/max size clamping (fully backward compatible)
- **Gallery demo** — Grid Layout demo page (header/sidebar/main/footer) registered in the launcher
- **Tests** — 9 grid layout tests + 3 flex constraint tests

## Details

### Grid_layout

New module in `miaou_widgets_layout` implementing a CSS Grid-inspired 2D layout:

```ocaml
let grid = Grid_layout.create
  ~rows:[Px 3; Fr 1.; Px 1]
  ~cols:[Px 20; Fr 1.]
  ~col_gap:1
  [
    span ~row:0 ~col:0 ~row_span:1 ~col_span:2 render_header;
    cell ~row:1 ~col:0 render_sidebar;
    cell ~row:1 ~col:1 render_main;
    span ~row:2 ~col:0 ~row_span:1 ~col_span:2 render_footer;
  ]
```

### Flex_layout constraints

New optional `?constraints` parameter — existing code is unaffected:

```ocaml
Flex_layout.create ~direction:Row
  ~constraints:[{ index = 0; min_size = Some 20; max_size = Some 40 }]
  children
```

## Test plan

- [x] `dune build` compiles cleanly
- [x] `dune runtest` — all 9 grid tests and 8 flex tests (including 3 new constraint tests) pass
- [ ] Run gallery demo and verify Grid Layout page renders correctly
- [ ] Resize terminal to verify Fr/Percent tracks adapt