### PR TITLE
fix: move web demo to miaou package to avoid SDL dependency

### DIFF
--- a/example/gallery/dune
+++ b/example/gallery/dune
@@ -60,7 +60,7 @@
 (executable
  (name main_web)
  (public_name miaou.demo-web)
- (package miaou-driver-web)
+ (package miaou)
  (modules main_web)
  (preprocess
   (pps ppx_blob))


### PR DESCRIPTION
## Summary

- Move `main_web` demo executable from `miaou-driver-web` package to `miaou` package
- This matches all other demo executables (`main_tui`, `main_sdl`, `main_matrix`) which are already in the `miaou` package

## Problem

Installing `miaou-driver-web` fails unless SDL libraries are available, because `dune build -p miaou-driver-web` includes the `main_web` demo which depends on `gallery` → `image_demo` → `tsdl-ttf`.

The `miaou-driver-web` library itself has **no SDL dependencies** — only the demo does.

## Fix

One-line change: `(package miaou-driver-web)` → `(package miaou)` in `example/gallery/dune`.

Fixes #65