### PR TITLE
fix(packaging): move web demo executable to miaou package

### DIFF
--- a/example/gallery/dune
+++ b/example/gallery/dune
@@ -60,7 +60,7 @@
 (executable
  (name main_web)
  (public_name miaou.demo-web)
- (package miaou-driver-web)
+ (package miaou)
  (modules main_web)
  (preprocess
   (pps ppx_blob))


### PR DESCRIPTION
## Summary

- Move `miaou.demo-web` executable from `(package miaou-driver-web)` to `(package miaou)`
- The demo depends on the `gallery` library which transitively requires SDL (tsdl-ttf), making `opam install miaou-driver-web` pull in unnecessary SDL system dependencies
- Now consistent with all other demo executables (`main_tui`, `main_sdl`, `main_matrix`)

Fixes #65

## Test plan

- [x] `dune build` succeeds
- [ ] `opam install miaou-driver-web` no longer requires SDL dependencies