### PR TITLE
fix(web): terminal now fits browser window size

### DIFF
--- a/src/miaou_driver_web/static/client.js
+++ b/src/miaou_driver_web/static/client.js
@@ -77,7 +77,8 @@ window.MiaouTerminal = function (container, options) {
   var fitAddon = new window.FitAddon.FitAddon();
   term.loadAddon(fitAddon);
   term.open(container);
-  fitAddon.fit();
+  // Defer initial fit so the browser has settled the layout
+  requestAnimationFrame(function () { fitAddon.fit(); });
 
   function buildWsUrl(password) {
     var protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -112,6 +113,7 @@ window.MiaouTerminal = function (container, options) {
             onRole(role);
             if (role === 'controller') {
               onStatusChange('connected', 'Connected');
+              fitAddon.fit();
               var dims = fitAddon.proposeDimensions();
               if (dims) {
                 ws.send(JSON.stringify({

--- a/src/miaou_driver_web/static/index.html
+++ b/src/miaou_driver_web/static/index.html
@@ -8,7 +8,7 @@
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html, body { width: 100%; height: 100%; background: #1e1e1e; overflow: hidden; }
-    #terminal { width: 100%; height: 100%; }
+    #terminal { width: 100%; height: calc(100% - 20px); }
     #status {
       position: fixed; bottom: 0; left: 0; right: 0;
       background: #333; color: #aaa; padding: 2px 8px;

--- a/src/miaou_driver_web/static/viewer.html
+++ b/src/miaou_driver_web/static/viewer.html
@@ -8,7 +8,7 @@
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html, body { width: 100%; height: 100%; background: #1e1e1e; overflow: hidden; }
-    #terminal { width: 100%; height: 100%; }
+    #terminal { width: 100%; height: calc(100% - 20px); }
     #status {
       position: fixed; bottom: 0; left: 0; right: 0;
       background: #333; color: #aaa; padding: 2px 8px;


### PR DESCRIPTION
## Summary

- Account for the fixed status bar height in `#terminal` CSS (`calc(100% - 20px)` instead of `100%`) in both `index.html` and `viewer.html`
- Defer initial `fitAddon.fit()` via `requestAnimationFrame` so the browser has settled the layout before measuring
- Call `fitAddon.fit()` when the controller role is assigned, before sending dimensions to the server — previously only `proposeDimensions()` was called which reads but doesn't apply the fit

Fixes #67

## Test plan

- [x] `dune build` succeeds
- [ ] Open `http://localhost:8080` — terminal fills the browser viewport above the status bar
- [ ] Resize browser window — terminal resizes accordingly
- [ ] Open `/viewer` — same sizing behavior