### PR TITLE
fix!: replace navigation magic strings with variant type

### DIFF
--- a/src/miaou_core/modal_manager.ml
+++ b/src/miaou_core/modal_manager.ml
@@ -183,9 +183,9 @@ let take_consume_next_key () =
    Modal callbacks can call set_pending_navigation to request navigation
    without needing access to the parent page's pstate. The driver checks
    this after modal close and applies it to the pstate. *)
-let pending_navigation_ref : string option ref = ref None
+let pending_navigation_ref : Navigation.nav option ref = ref None
 
-let set_pending_navigation page = pending_navigation_ref := Some page
+let set_pending_navigation nav = pending_navigation_ref := Some nav
 
 let take_pending_navigation () =
   let v = !pending_navigation_ref in

--- a/src/miaou_core/modal_manager.mli
+++ b/src/miaou_core/modal_manager.mli
@@ -142,7 +142,7 @@ val take_consume_next_key : unit -> bool
     {[
       ~on_close:(fun _modal_state outcome ->
         match outcome with
-        | `Commit -> Modal_manager.set_pending_navigation "next_page"
+        | `Commit -> Modal_manager.set_pending_navigation (Navigation.Goto "next_page")
         | `Cancel -> ())
     ]}
 
@@ -150,15 +150,15 @@ val take_consume_next_key : unit -> bool
     modal callbacks, which was error-prone and required pages to check the ref
     in [service_cycle].
 *)
-val set_pending_navigation : string -> unit
+val set_pending_navigation : Navigation.nav -> unit
 
 (** Read and clear the pending navigation request.
 
-    Returns [Some page_name] exactly once after [set_pending_navigation] was
+    Returns [Some nav] exactly once after [set_pending_navigation] was
     called. This is used by drivers to apply navigation after modal close.
     You typically don't need to call this function yourself.
 *)
-val take_pending_navigation : unit -> string option
+val take_pending_navigation : unit -> Navigation.nav option
 
 (* Access the UI metadata for the top-most modal, if any. *)
 val top_ui_opt : unit -> ui option

--- a/src/miaou_core/navigation.ml
+++ b/src/miaou_core/navigation.ml
@@ -9,15 +9,17 @@
     Pages work with ['a pstate] instead of raw state, enabling
     framework-managed navigation without boilerplate. *)
 
-type 'a t = {s : 'a; nav : string option}
+type nav = Goto of string | Back | Quit
+
+type 'a t = {s : 'a; nav : nav option}
 
 let make s = {s; nav = None}
 
-let goto page ps = {ps with nav = Some page}
+let goto page ps = {ps with nav = Some (Goto page)}
 
-let back ps = {ps with nav = Some "__BACK__"}
+let back ps = {ps with nav = Some Back}
 
-let quit ps = {ps with nav = Some "__QUIT__"}
+let quit ps = {ps with nav = Some Quit}
 
 let pending ps = ps.nav
 

--- a/src/miaou_core/navigation.mli
+++ b/src/miaou_core/navigation.mli
@@ -22,16 +22,28 @@
         | _ -> ps
     ]}
 
-    {2 Benefits}
-    - No [next_page] field in page state
-    - No [next_page] accessor function required
-    - Clear, named navigation functions
-    - Pure functional style (no side effects)
+    {2 Type-safe navigation}
+
+    Navigation uses a variant type to prevent common mistakes:
+    - [Goto "page"] pushes the current page onto the history stack and
+      navigates to the named page.
+    - [Back] pops the previous page from the history stack.
+    - [Quit] exits the application.
+
+    Using a variant instead of magic strings makes it impossible to
+    accidentally use [goto "parent_page"] when [back] is intended,
+    which previously caused infinite navigation loops.
 *)
+
+(** Navigation target. *)
+type nav =
+  | Goto of string  (** Navigate to the named page (pushes current to stack) *)
+  | Back  (** Return to the previous page in the history stack *)
+  | Quit  (** Exit the application *)
 
 type 'a t = {
   s : 'a;  (** The page's own state *)
-  nav : string option;  (** Pending navigation target, if any *)
+  nav : nav option;  (** Pending navigation target, if any *)
 }
 
 (** [make s] wraps a page state with no pending navigation. *)
@@ -48,7 +60,7 @@ val quit : 'a t -> 'a t
 
 (** [pending ps] returns the pending navigation target, if any.
     Used by the framework after handlers return. *)
-val pending : 'a t -> string option
+val pending : 'a t -> nav option
 
 (** [update f ps] applies [f] to the inner state.
     Shorthand for [{ps with s = f ps.s}]. *)

--- a/src/miaou_core/tui_driver.mli
+++ b/src/miaou_core/tui_driver.mli
@@ -20,6 +20,6 @@ val flush : unit -> unit
 
 val set_page : (module PAGE_SIG) -> unit
 
-type outcome = [`Quit | `SwitchTo of string]
+type outcome = [`Quit | `Back | `SwitchTo of string]
 
 val run : (module PAGE_SIG) -> outcome

--- a/src/miaou_driver_common/driver_common.ml
+++ b/src/miaou_driver_common/driver_common.ml
@@ -50,7 +50,7 @@ module Make (Backend : DRIVER_BACKEND) = struct
     let rec loop : type s.
         (module PAGE_SIG with type state = s) ->
         s Navigation.t ->
-        [`Quit | `SwitchTo of string] =
+        [`Quit | `Back | `SwitchTo of string] =
      fun (module P : PAGE_SIG with type state = s) (ps : s Navigation.t) ->
       let size = Backend.detect_size () in
       let lterm_size = LTerm_geom.{rows = size.rows; cols = size.cols} in
@@ -68,8 +68,9 @@ module Make (Backend : DRIVER_BACKEND) = struct
       | Refresh -> (
           let ps' = P.refresh ps in
           match Navigation.pending ps' with
-          | Some "__QUIT__" -> `Quit
-          | Some name -> (
+          | Some Navigation.Quit -> `Quit
+          | Some Navigation.Back -> `Back
+          | Some (Navigation.Goto name) -> (
               match Registry.find name with
               | Some (module Next : PAGE_SIG) ->
                   let ps_to = Next.init () in
@@ -89,8 +90,9 @@ module Make (Backend : DRIVER_BACKEND) = struct
               | _ -> P.handle_key ps k ~size:lterm_size
           in
           match Navigation.pending ps' with
-          | Some "__QUIT__" -> `Quit
-          | Some name -> (
+          | Some Navigation.Quit -> `Quit
+          | Some Navigation.Back -> `Back
+          | Some (Navigation.Goto name) -> (
               match Registry.find name with
               | Some (module Next : PAGE_SIG) ->
                   let ps_to = Next.init () in

--- a/src/miaou_driver_common/driver_common.mli
+++ b/src/miaou_driver_common/driver_common.mli
@@ -55,5 +55,5 @@ end
 (** Functor to create a complete driver from a backend implementation *)
 module Make (Backend : DRIVER_BACKEND) : sig
   (** Run the application with the given initial page *)
-  val run : (module PAGE_SIG) -> [`Quit | `SwitchTo of string]
+  val run : (module PAGE_SIG) -> [`Quit | `Back | `SwitchTo of string]
 end

--- a/src/miaou_driver_common/page_transition_utils.ml
+++ b/src/miaou_driver_common/page_transition_utils.ml
@@ -11,6 +11,7 @@ module Navigation = Miaou_core.Navigation
 
 type 'r handler = {
   on_quit : unit -> 'r;
+  on_back : unit -> 'r;
   on_same_page : unit -> 'r;
   on_new_page :
     'new_s.
@@ -22,15 +23,18 @@ let handle_next_page (type s r) (module P : PAGE_SIG with type state = s)
   (* Check for pending navigation from modal callbacks *)
   let ps =
     match Miaou_core.Modal_manager.take_pending_navigation () with
-    | Some page -> Navigation.goto page ps
+    | Some (Navigation.Goto page) -> Navigation.goto page ps
+    | Some Navigation.Back -> Navigation.back ps
+    | Some Navigation.Quit -> Navigation.quit ps
     | None -> ps
   in
   match Navigation.pending ps with
-  | Some "__QUIT__" -> handler.on_quit ()
-  | Some name -> (
+  | Some Navigation.Quit -> handler.on_quit ()
+  | Some (Navigation.Goto name) -> (
       match Registry.find name with
       | Some (module Next : PAGE_SIG) ->
           let ps_to = Next.init () in
           handler.on_new_page (module Next) ps_to
       | None -> handler.on_quit ())
+  | Some Navigation.Back -> handler.on_back ()
   | None -> handler.on_same_page ()

--- a/src/miaou_driver_common/page_transition_utils.mli
+++ b/src/miaou_driver_common/page_transition_utils.mli
@@ -10,6 +10,7 @@ module Navigation = Miaou_core.Navigation
 
 type 'r handler = {
   on_quit : unit -> 'r;
+  on_back : unit -> 'r;
   on_same_page : unit -> 'r;
   on_new_page :
     'new_s.
@@ -18,7 +19,8 @@ type 'r handler = {
 
 (** [handle_next_page page_module ps handler] checks if the current page requests
     a transition and invokes the appropriate callback:
-    - Calls [handler.on_quit ()] if the page requests "__QUIT__" or an unknown page
+    - Calls [handler.on_quit ()] if the page requests [Quit] or an unknown page
+    - Calls [handler.on_back ()] if the page requests [Back]
     - Calls [handler.on_same_page ()] if no transition requested
     - Calls [handler.on_new_page next_module next_pstate] if transitioning to a valid page
 

--- a/src/miaou_driver_matrix/matrix_driver.ml
+++ b/src/miaou_driver_matrix/matrix_driver.ml
@@ -17,7 +17,7 @@ let available = true
 module Fibers = Miaou_helpers.Fiber_runtime
 
 let run ?(config = None) (initial_page : (module Tui_page.PAGE_SIG)) :
-    [`Quit | `SwitchTo of string] =
+    [`Quit | `Back | `SwitchTo of string] =
   Fibers.with_page_switch (fun env _page_sw ->
       (* Load configuration *)
       let config =

--- a/src/miaou_driver_matrix/matrix_main_loop.mli
+++ b/src/miaou_driver_matrix/matrix_main_loop.mli
@@ -34,4 +34,4 @@ val run :
   context ->
   env:Eio_unix.Stdenv.base ->
   (module Miaou_core.Tui_page.PAGE_SIG) ->
-  [`Quit | `SwitchTo of string]
+  [`Quit | `Back | `SwitchTo of string]

--- a/src/miaou_driver_sdl/sdl_driver.ml
+++ b/src/miaou_driver_sdl/sdl_driver.ml
@@ -554,7 +554,7 @@ let render_page (type s) (module P : PAGE_SIG with type state = s)
     ~cols:size.cols
 
 let run_with_sdl (initial_page : (module PAGE_SIG)) (cfg : config) :
-    [`Quit | `SwitchTo of string] =
+    [`Quit | `Back | `SwitchTo of string] =
   let available = true in
   ignore available ;
   Fibers.with_page_scope (fun () ->
@@ -684,7 +684,7 @@ let run_with_sdl (initial_page : (module PAGE_SIG)) (cfg : config) :
       let rec loop : type s.
           (module PAGE_SIG with type state = s) ->
           s Page_transition.Navigation.t ->
-          [`Quit | `SwitchTo of string] =
+          [`Quit | `Back | `SwitchTo of string] =
        fun (module P : PAGE_SIG with type state = s)
            (ps : s Page_transition.Navigation.t)
          ->
@@ -698,6 +698,7 @@ let run_with_sdl (initial_page : (module PAGE_SIG)) (cfg : config) :
               ps'
               {
                 on_quit = (fun () -> `Quit);
+                on_back = (fun () -> `Back);
                 on_same_page = (fun () -> loop (module P) ps');
                 on_new_page =
                   (fun (type a)
@@ -810,6 +811,7 @@ let run_with_sdl (initial_page : (module PAGE_SIG)) (cfg : config) :
                 ps'
                 {
                   on_quit = (fun () -> `Quit);
+                  on_back = (fun () -> `Back);
                   on_same_page = (fun () -> loop (module P) ps');
                   on_new_page =
                     (fun (type a)

--- a/src/miaou_driver_term/term_test_runner.ml
+++ b/src/miaou_driver_term/term_test_runner.ml
@@ -22,19 +22,22 @@ type driver_key = Term_events.driver_key =
   | Other of string
 
 let run_with_key_source ~read_key (module Page : PAGE_SIG) :
-    [`Quit | `SwitchTo of string] =
+    [`Quit | `Back | `SwitchTo of string] =
   let default_size = {LTerm_geom.rows = 24; cols = 80} in
   (* Helper: apply any pending navigation from modal callbacks *)
   let apply_pending_modal_nav ps =
     match Modal_manager.take_pending_navigation () with
-    | Some page -> Navigation.goto page ps
+    | Some (Navigation.Goto page) -> Navigation.goto page ps
+    | Some Navigation.Back -> Navigation.back ps
+    | Some Navigation.Quit -> Navigation.quit ps
     | None -> ps
   in
   let check_nav ps =
     let ps = apply_pending_modal_nav ps in
     match Navigation.pending ps with
-    | Some "__QUIT__" -> `Quit
-    | Some p -> `SwitchTo p
+    | Some Navigation.Quit -> `Quit
+    | Some Navigation.Back -> `Back
+    | Some (Navigation.Goto p) -> `SwitchTo p
     | None -> `Continue ps
   in
   let rec loop ps =
@@ -44,8 +47,7 @@ let run_with_key_source ~read_key (module Page : PAGE_SIG) :
         let ps' = Page.service_cycle (Page.refresh ps) 0 in
         match check_nav ps' with
         | `Continue ps'' -> loop ps''
-        | `Quit -> `Quit
-        | `SwitchTo p -> `SwitchTo p)
+        | (`Quit | `Back | `SwitchTo _) as r -> r)
     | Enter -> (
         if Modal_manager.has_active () then (
           Modal_manager.handle_key "Enter" ;
@@ -55,13 +57,13 @@ let run_with_key_source ~read_key (module Page : PAGE_SIG) :
               let ps'' = Page.service_cycle ps' 0 in
               match check_nav ps'' with
               | `Continue ps''' -> loop ps'''
-              | (`Quit | `SwitchTo _) as r -> r
+              | (`Quit | `Back | `SwitchTo _) as r -> r
             else loop ps'
           else if not (Modal_manager.has_active ()) then
             let ps'' = Page.service_cycle ps' 0 in
             match check_nav ps'' with
             | `Continue ps''' -> loop ps'''
-            | (`Quit | `SwitchTo _) as r -> r
+            | (`Quit | `Back | `SwitchTo _) as r -> r
           else loop ps')
         else
           match check_nav ps with
@@ -69,21 +71,17 @@ let run_with_key_source ~read_key (module Page : PAGE_SIG) :
               let ps' = Page.handle_key ps "Enter" ~size:default_size in
               match check_nav ps' with
               | `Continue ps'' -> loop ps''
-              | `Quit -> `Quit
-              | `SwitchTo p -> `SwitchTo p)
-          | `Quit -> `Quit
-          | `SwitchTo p -> `SwitchTo p)
+              | (`Quit | `Back | `SwitchTo _) as r -> r)
+          | (`Quit | `Back | `SwitchTo _) as r -> r)
     | Up | Down | Left | Right | NextPage | PrevPage -> loop ps
     | Other key -> (
         let ps' = Page.handle_key ps key ~size:default_size in
         match check_nav ps' with
         | `Continue ps'' -> loop ps''
-        | `Quit -> `Quit
-        | `SwitchTo p -> `SwitchTo p)
+        | (`Quit | `Back | `SwitchTo _) as r -> r)
   in
   Modal_manager.clear () ;
   let ps0 = Page.init () in
   match check_nav ps0 with
   | `Continue ps0' -> loop ps0'
-  | `Quit -> `Quit
-  | `SwitchTo p -> `SwitchTo p
+  | (`Quit | `Back | `SwitchTo _) as r -> r

--- a/src/miaou_driver_term/term_test_runner.mli
+++ b/src/miaou_driver_term/term_test_runner.mli
@@ -21,4 +21,4 @@ type driver_key = Term_events.driver_key =
 val run_with_key_source :
   read_key:(unit -> driver_key) ->
   (module Miaou_core.Tui_page.PAGE_SIG) ->
-  [`Quit | `SwitchTo of string]
+  [`Quit | `Back | `SwitchTo of string]

--- a/src/miaou_driver_web/web_driver.ml
+++ b/src/miaou_driver_web/web_driver.ml
@@ -205,7 +205,7 @@ let parse_client_message events ~current_rows ~current_cols msg =
       | exception _ -> ())
   | exception _ -> ()
 
-exception Tui_done of ([`Quit | `SwitchTo of string] * (int * int))
+exception Tui_done of ([`Quit | `Back | `SwitchTo of string] * (int * int))
 
 (* Run the TUI over an established WebSocket connection.
    [~initial_size] can be passed to skip waiting for resize on page switch. *)
@@ -370,8 +370,8 @@ let run_tui (env : Eio_unix.Stdenv.base) config session ws br
 let run ?(config = None) ?(port = 8080) ?auth
     ?(controller_html = Web_assets.index_html)
     ?(viewer_html = Web_assets.viewer_html) ?(extra_assets = [])
-    (initial_page : (module Tui_page.PAGE_SIG)) : [`Quit | `SwitchTo of string]
-    =
+    (initial_page : (module Tui_page.PAGE_SIG)) :
+    [`Quit | `Back | `SwitchTo of string] =
   Fibers.with_page_switch (fun env page_sw ->
       Printf.eprintf "Miaou web driver: http://127.0.0.1:%d\n%!" port ;
       let socket =
@@ -464,7 +464,7 @@ let run ?(config = None) ?(port = 8080) ?auth
                            in
                            match result with
                            | `Quit -> Web_websocket.close ws
-                           | `SwitchTo "__BACK__" -> (
+                           | `Back -> (
                                match !page_stack with
                                | [] -> Web_websocket.close ws
                                | prev :: rest ->

--- a/src/miaou_driver_web/web_driver.mli
+++ b/src/miaou_driver_web/web_driver.mli
@@ -60,4 +60,4 @@ val run :
   ?viewer_html:string ->
   ?extra_assets:extra_asset list ->
   (module Miaou_core.Tui_page.PAGE_SIG) ->
-  [`Quit | `SwitchTo of string]
+  [`Quit | `Back | `SwitchTo of string]

--- a/src/miaou_runner/miaou_runner_native_main.ml
+++ b/src/miaou_runner/miaou_runner_native_main.ml
@@ -6,4 +6,4 @@ let () =
   let page_name = Cli.pick_page ~argv:Sys.argv in
   let page = Cli.find_page page_name in
   match Miaou_runner_native.Runner_native.run page with
-  | `Quit | `SwitchTo _ -> ()
+  | `Quit | `Back | `SwitchTo _ -> ()

--- a/src/miaou_runner/miaou_runner_tui_main.ml
+++ b/src/miaou_runner/miaou_runner_tui_main.ml
@@ -5,4 +5,5 @@ let () =
   let module Cli = Miaou_runner_common.Runner_cli in
   let page_name = Cli.pick_page ~argv:Sys.argv in
   let page = Cli.find_page page_name in
-  match Miaou_runner_tui.Runner_tui.run page with `Quit | `SwitchTo _ -> ()
+  match Miaou_runner_tui.Runner_tui.run page with
+  | `Quit | `Back | `SwitchTo _ -> ()

--- a/src/miaou_runner/tui_driver_common.ml
+++ b/src/miaou_runner/tui_driver_common.ml
@@ -12,7 +12,7 @@ module Widgets = Miaou_widgets_display.Widgets
 module Registry = Miaou_core.Registry
 
 (* Local alias for outcome to ensure compilation when mli changes are applied *)
-type outcome = [`Quit | `SwitchTo of string]
+type outcome = [`Quit | `Back | `SwitchTo of string]
 
 type backend = {available : bool; run : (module PAGE_SIG) -> outcome}
 
@@ -56,7 +56,7 @@ let backend_choice ~sdl_available ~matrix_available ~web_available =
 let run ~term_backend ~sdl_backend ~matrix_backend ~web_backend
     (initial_page : (module PAGE_SIG)) : outcome =
   Widgets.set_backend `Terminal ;
-  (* Page stack for __BACK__ navigation *)
+  (* Page stack for Back navigation *)
   let page_stack = ref [] in
   let rec loop (page : (module PAGE_SIG)) : outcome =
     let outcome =
@@ -84,7 +84,7 @@ let run ~term_backend ~sdl_backend ~matrix_backend ~web_backend
     in
     match outcome with
     | `Quit -> `Quit
-    | `SwitchTo "__BACK__" -> (
+    | `Back -> (
         match !page_stack with
         | [] -> `Quit (* No history, quit *)
         | prev :: rest ->

--- a/test/test_core_driver_modal_navigation.ml
+++ b/test/test_core_driver_modal_navigation.ml
@@ -88,7 +88,9 @@ module Dummy_page : Miaou_core.Tui_page.PAGE_SIG = struct
       ~cancel_on:[]
       ~on_close:(fun _ outcome ->
         match outcome with
-        | `Commit -> Miaou_core.Modal_manager.set_pending_navigation "NEXT"
+        | `Commit ->
+            Miaou_core.Modal_manager.set_pending_navigation
+              (Miaou_core.Navigation.Goto "NEXT")
         | _ -> ())
 
   let init () =
@@ -153,6 +155,7 @@ let test_modal_consumes_enter_triggers_navigation () =
   check
     (Alcotest.of_pp (fun fmt -> function
       | `Quit -> Format.fprintf fmt "Quit"
+      | `Back -> Format.fprintf fmt "Back"
       | `SwitchTo s -> Format.fprintf fmt "SwitchTo %s" s))
     "navigation triggered"
     (`SwitchTo "NEXT")

--- a/test/test_driver_modal_navigation.ml
+++ b/test/test_driver_modal_navigation.ml
@@ -88,7 +88,9 @@ module Dummy_page : Miaou_core.Tui_page.PAGE_SIG = struct
       ~cancel_on:[]
       ~on_close:(fun _ outcome ->
         match outcome with
-        | `Commit -> Miaou_core.Modal_manager.set_pending_navigation "NEXT"
+        | `Commit ->
+            Miaou_core.Modal_manager.set_pending_navigation
+              (Miaou_core.Navigation.Goto "NEXT")
         | _ -> ())
 
   let init () =
@@ -153,6 +155,7 @@ let test_modal_consumes_enter_triggers_navigation () =
   check
     (Alcotest.of_pp (fun fmt -> function
       | `Quit -> Format.fprintf fmt "Quit"
+      | `Back -> Format.fprintf fmt "Back"
       | `SwitchTo s -> Format.fprintf fmt "SwitchTo %s" s))
     "navigation triggered"
     (`SwitchTo "NEXT")

--- a/test/test_headless_run.ml
+++ b/test/test_headless_run.ml
@@ -69,7 +69,7 @@ let test_run_loop () =
     bool
     "quit or switch"
     true
-    (match res with `Quit | `SwitchTo _ -> true)
+    (match res with `Quit | `Back | `SwitchTo _ -> true)
 
 let () =
   run


### PR DESCRIPTION
## Summary

Replaces `"__BACK__"` and `"__QUIT__"` magic strings in the Navigation module with a proper variant type, preventing developers from accidentally creating infinite navigation loops.

Fixes #18

## Changes

- Add `Navigation.nav` type with `Goto of string | Back | Quit` constructors
- Add `` `Back `` arm to driver outcome type across all backends (matrix, lambda-term, SDL, web, headless)
- Add `on_back` callback to `page_transition_utils` handler record
- Update `Modal_manager.set_pending_navigation` to accept `Navigation.nav`
- Update all drivers, runners, and tests

## Breaking Changes

- `Navigation.pending` now returns `Navigation.nav option` instead of `string option`
- `Modal_manager.set_pending_navigation` now takes `Navigation.nav` instead of `string`
- Driver outcome type gains `` `Back `` variant — downstream match sites need updating

## Migration

```ocaml
(* Before *)
match Navigation.pending ps with
| Some "__QUIT__" -> handle_quit ()
| Some "__BACK__" -> handle_back ()
| Some name -> handle_goto name
| None -> continue ()

(* After *)
match Navigation.pending ps with
| Some Navigation.Quit -> handle_quit ()
| Some Navigation.Back -> handle_back ()
| Some (Navigation.Goto name) -> handle_goto name
| None -> continue ()
```

```ocaml
(* Before *)
Modal_manager.set_pending_navigation "some_page"

(* After *)
Modal_manager.set_pending_navigation (Navigation.Goto "some_page")
```