### PR TITLE
feat(runner): add non-interactive CLI output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ dune exec -- miaou.demo             # TUI-only demo (lambda-term)
 dune exec -- miaou.demo-sdl         # SDL demo with enhanced graphics
 dune exec -- miaou-runner-tui       # generic runner forcing TUI
 dune exec -- miaou-runner-native    # generic runner preferring SDL
+
+# Pure CLI output (non-interactive snapshot)
+dune exec -- miaou-runner-tui -- --page main --cli-output --cols 100 --rows 28 --ticks 2
 ```
 
 For the best SDL experience with transitions:
@@ -768,4 +771,3 @@ match Registry.conflict_report () with
 - ✅ **Runtime validation**: Conflicts detected at registration
 - ✅ **Self-documenting**: `handled_keys` serves as documentation
 - ✅ **Auto-generated help**: Future help system can introspect keys
-

--- a/src/miaou_runner/miaou_runner_native_main.ml
+++ b/src/miaou_runner/miaou_runner_native_main.ml
@@ -3,7 +3,11 @@ let () =
   Eio.Switch.run @@ fun sw ->
   Miaou_helpers.Fiber_runtime.init ~env ~sw ;
   let module Cli = Miaou_runner_common.Runner_cli in
-  let page_name = Cli.pick_page ~argv:Sys.argv in
-  let page = Cli.find_page page_name in
-  match Miaou_runner_native.Runner_native.run page with
-  | `Quit | `Back | `SwitchTo _ -> ()
+  let opts = Cli.parse ~argv:Sys.argv in
+  let page = Cli.find_page opts.page_name in
+  if opts.cli_output then
+    print_endline
+      (Cli.render_cli ~rows:opts.rows ~cols:opts.cols ~ticks:opts.ticks page)
+  else
+    match Miaou_runner_native.Runner_native.run page with
+    | `Quit | `Back | `SwitchTo _ -> ()

--- a/src/miaou_runner/miaou_runner_tui_main.ml
+++ b/src/miaou_runner/miaou_runner_tui_main.ml
@@ -3,7 +3,11 @@ let () =
   Eio.Switch.run @@ fun sw ->
   Miaou_helpers.Fiber_runtime.init ~env ~sw ;
   let module Cli = Miaou_runner_common.Runner_cli in
-  let page_name = Cli.pick_page ~argv:Sys.argv in
-  let page = Cli.find_page page_name in
-  match Miaou_runner_tui.Runner_tui.run page with
-  | `Quit | `Back | `SwitchTo _ -> ()
+  let opts = Cli.parse ~argv:Sys.argv in
+  let page = Cli.find_page opts.page_name in
+  if opts.cli_output then
+    print_endline
+      (Cli.render_cli ~rows:opts.rows ~cols:opts.cols ~ticks:opts.ticks page)
+  else
+    match Miaou_runner_tui.Runner_tui.run page with
+    | `Quit | `Back | `SwitchTo _ -> ()


### PR DESCRIPTION
## Summary
- add `--cli-output` runner mode to render a page snapshot to stdout and exit
- support `--cols`, `--rows`, and `--ticks` to control snapshot dimensions and warmup refresh cycles
- wire CLI mode into both `miaou-runner-tui` and `miaou-runner-native`
- document CLI snapshot usage in README examples

## Validation
- dune fmt
- dune build
- dune runtest