### PR TITLE
docs(widgets): clarify chart color parameters and precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ Documentation
 - **[Getting Started](./docs/getting-started.md)** — Build your first MIAOU application
 - **[Architecture Overview](./docs/architecture.md)** — Core components, pages, modals, widgets
 - **[Capabilities Guide](./docs/capabilities.md)** — Dependency injection system
+- **[Color Guide](./docs/colors.md)** — ANSI color payloads and chart precedence rules
 - **[Examples](./example/README.md)** — Demo applications and widget showcases
 
 Further reading

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -1,0 +1,61 @@
+# Color Guide
+
+Miaou chart widgets that expose a `color : string option` field expect ANSI SGR
+foreground payloads as strings.
+
+Use values that can appear inside `\027[<payload>m`.
+
+- Basic ANSI colors: `"30"` .. `"37"`
+- Bright ANSI colors: `"90"` .. `"97"`
+- 256-color foreground: `"38;5;<n>"` where `<n>` is `0..255`
+
+Do not pass raw palette indices like `"196"`; use `"38;5;196"`.
+
+## Line Chart precedence
+
+- Point `color` overrides series `color`
+- Series `color` overrides thresholds
+- Thresholds apply only when both point and series colors are absent
+
+## Sparkline precedence
+
+- Matching threshold color is used first
+- Then the render `~color` argument
+- Then widget fallback color
+
+## Advanced example: diagnostics panel
+
+```ocaml
+module LC = Miaou_widgets_display.Line_chart_widget
+module SP = Miaou_widgets_display.Sparkline_widget
+
+let mk_latency_chart ~samples =
+  let points =
+    List.mapi
+      (fun i y ->
+        let point_color = if y > 120.0 then Some "38;5;196" else None in
+        {LC.x = float_of_int i; y; color = point_color})
+      samples
+  in
+  let series =
+    {
+      LC.label = "Render latency";
+      points;
+      color = Some "38;5;81";
+    }
+  in
+  LC.create ~width:64 ~height:14 ~series:[series] ~title:"Latency (ms)" ()
+
+let render_cpu_spark spark =
+  SP.render
+    spark
+    ~focus:true
+    ~show_value:true
+    ~color:"38;5;45"
+    ~thresholds:
+      [
+        {SP.value = 50.0; color = "38;5;226"};
+        {SP.value = 80.0; color = "38;5;196"};
+      ]
+    ()
+```

--- a/src/miaou_widgets_display/line_chart_widget.mli
+++ b/src/miaou_widgets_display/line_chart_widget.mli
@@ -40,6 +40,32 @@
     v}
 *)
 
+(** {1 Color parameters}
+
+    Color fields in this module use ANSI SGR foreground color numbers encoded
+    as strings (for example ["31"] for red, ["38;5;196"] for 256-color bright
+    red).
+
+    These values are not plain palette indices like ["196"]; pass complete SGR
+    payloads as expected by [\027[<payload>m].
+
+    Useful forms:
+    - Basic ANSI colors: ["30"]..["37"]
+    - Bright ANSI colors: ["90"]..["97"]
+    - 256-color foreground: ["38;5;<n>"] where [n] is [0..255]
+
+    Precedence when rendering points:
+    - point [color] overrides series [color]
+    - series [color] overrides threshold [color]
+    - thresholds apply only when both point and series colors are absent
+
+    Example:
+    {[ let points = [{ x = 1.0; y = 2.0; color = Some "32" }] in
+       let series = { label = "temperature"; points; color = Some "38;5;203" } in
+       let chart = Line_chart_widget.create ~width:40 ~height:10 ~series:[series] () in
+       Line_chart_widget.render chart ~show_axes:true ~show_grid:false () ]}
+*)
+
 (** A 2D data point with an optional override color. *)
 type point = {x : float; y : float; color : string option}
 

--- a/src/miaou_widgets_display/sparkline_widget.mli
+++ b/src/miaou_widgets_display/sparkline_widget.mli
@@ -23,6 +23,24 @@
     Output: [ ▃▄▆▇█▇▅▃▂ ▂▃▅▆▇█▇▆▄▃▂ ] 42.3%
 *)
 
+(** {1 Color parameters}
+
+    Sparkline colors use ANSI SGR foreground color numbers encoded as strings,
+    such as ["32"] (green) or ["38;5;214"] (orange in the 256-color palette).
+
+    These values are SGR payloads and not raw palette indices.
+
+    Useful forms:
+    - Basic ANSI colors: ["30"]..["37"]
+    - Bright ANSI colors: ["90"]..["97"]
+    - 256-color foreground: ["38;5;<n>"] where [n] is [0..255]
+
+    Precedence when rendering each segment:
+    - threshold color for that value (if matched)
+    - otherwise default [color] argument
+    - otherwise widget fallback color
+*)
+
 (** A threshold for coloring sparkline segments with a value above it. *)
 type threshold = {value : float; color : string}
 


### PR DESCRIPTION
## Summary
- document ANSI color payload format for chart color fields in line chart and sparkline interfaces
- clarify point/series/threshold precedence rules for line charts and sparkline thresholds
- add a dedicated `docs/colors.md` guide with an advanced diagnostics-oriented example
- link the new color guide from the main README documentation section

## Validation
- dune fmt
- dune build
- dune runtest