### PR TITLE
feat(input_parser): add PageUp, PageDown, Home, End key variants

### DIFF
--- a/src/miaou_driver_common/input_parser.ml
+++ b/src/miaou_driver_common/input_parser.ml
@@ -21,6 +21,10 @@ type key =
   | Down
   | Left
   | Right
+  | PageUp
+  | PageDown
+  | Home
+  | End
   | Delete
   | Ctrl of char  (** C-a, C-b, etc. *)
   | Mouse of {row : int; col : int; button : int; release : bool}
@@ -136,6 +140,8 @@ let peek_key t =
         | 'B' -> Some Down
         | 'C' -> Some Right
         | 'D' -> Some Left
+        | 'H' -> Some Home
+        | 'F' -> Some End
         | 'Z' -> Some ShiftTab (* Shift+Tab: ESC [ Z *)
         | '3' ->
             (* Delete: ESC [ 3 ~ *)
@@ -145,7 +151,13 @@ let peek_key t =
         | '0' .. '9' -> (
             (* Numeric CSI sequence - check if complete *)
             match find_csi_end t.pending with
-            | Some (body, _len) -> Some (Unknown body)
+            | Some (body, _len) -> (
+                match body with
+                | "5" -> Some PageUp
+                | "6" -> Some PageDown
+                | "1" | "7" -> Some Home
+                | "4" | "8" -> Some End
+                | _ -> Some (Unknown body))
             | None -> None (* Incomplete *))
         | _ -> Some (Unknown (String.make 1 c))
       else if len >= 3 && String.get t.pending 1 = 'O' then
@@ -155,6 +167,8 @@ let peek_key t =
         | 'B' -> Some Down
         | 'C' -> Some Right
         | 'D' -> Some Left
+        | 'H' -> Some Home
+        | 'F' -> Some End
         | _ -> Some (Unknown (String.make 1 c))
       else if len = 1 then Some Escape
       else if len >= 2 then
@@ -167,6 +181,8 @@ let peek_key t =
 (** Bytes to consume for a given key type *)
 let bytes_for_key = function
   | Up | Down | Left | Right -> 3 (* ESC [ A/B/C/D *)
+  | PageUp | PageDown | Home | End ->
+      0 (* Variable-length CSI — handled like Mouse *)
   | Tab | Backspace | Enter -> 1
   | ShiftTab -> 3 (* ESC [ Z *)
   | AltEnter -> 2 (* ESC + newline *)
@@ -300,6 +316,12 @@ let parse_key t =
         | 'D' ->
             consume t 3 ;
             Some Left
+        | 'H' ->
+            consume t 3 ;
+            Some Home
+        | 'F' ->
+            consume t 3 ;
+            Some End
         | 'Z' ->
             (* Shift+Tab: ESC [ Z *)
             consume t 3 ;
@@ -328,9 +350,14 @@ let parse_key t =
             in
             wait_for_terminator 10 ;
             match find_csi_end t.pending with
-            | Some (body, seq_len) ->
+            | Some (body, seq_len) -> (
                 consume t seq_len ;
-                Some (Unknown body)
+                match body with
+                | "5" -> Some PageUp
+                | "6" -> Some PageDown
+                | "1" | "7" -> Some Home
+                | "4" | "8" -> Some End
+                | _ -> Some (Unknown body))
             | None ->
                 consume t 3 ;
                 Some (Unknown (String.make 1 c)))
@@ -346,6 +373,8 @@ let parse_key t =
         | 'B' -> Some Down
         | 'C' -> Some Right
         | 'D' -> Some Left
+        | 'H' -> Some Home
+        | 'F' -> Some End
         | _ -> Some (Unknown (String.make 1 c))
       end
       else if len >= 2 then begin
@@ -418,6 +447,10 @@ let key_to_string = function
   | Down -> "Down"
   | Left -> "Left"
   | Right -> "Right"
+  | PageUp -> "PageUp"
+  | PageDown -> "PageDown"
+  | Home -> "Home"
+  | End -> "End"
   | Delete -> "Delete"
   | Ctrl c -> "C-" ^ String.make 1 c
   | Mouse {row; col; _} -> Printf.sprintf "Mouse:%d:%d" row col
@@ -429,7 +462,8 @@ let key_to_string = function
 
 (** Check if key is a navigation key (for draining) *)
 let is_nav_key = function
-  | Up | Down | Left | Right | Tab | Delete -> true
+  | Up | Down | Left | Right | Tab | Delete | PageUp | PageDown | Home | End ->
+      true
   | _ -> false
 
 (** Get pending buffer length (for debugging) *)

--- a/src/miaou_driver_common/input_parser.mli
+++ b/src/miaou_driver_common/input_parser.mli
@@ -37,6 +37,10 @@ type key =
   | Down
   | Left
   | Right
+  | PageUp  (** ESC [ 5 ~ *)
+  | PageDown  (** ESC [ 6 ~ *)
+  | Home  (** ESC [ H, ESC O H, ESC [ 1 ~, ESC [ 7 ~ *)
+  | End  (** ESC [ F, ESC O F, ESC [ 4 ~, ESC [ 8 ~ *)
   | Delete
   | Ctrl of char  (** Control + letter, e.g., Ctrl 'a' for C-a *)
   | Mouse of {row : int; col : int; button : int; release : bool}
@@ -93,7 +97,7 @@ val drain_esc : t -> int
     [Mouse {row=5; col=10; _}] -> ["Mouse:5:10"] *)
 val key_to_string : key -> string
 
-(** Check if key is a navigation key (Up/Down/Left/Right/Tab/Delete).
+(** Check if key is a navigation key (Up/Down/Left/Right/Tab/Delete/PageUp/PageDown/Home/End).
     These are candidates for draining. *)
 val is_nav_key : key -> bool
 

--- a/src/miaou_driver_matrix/matrix_ansi_parser.ml
+++ b/src/miaou_driver_matrix/matrix_ansi_parser.ml
@@ -202,7 +202,7 @@ let parse_core t ~emit_char input =
         else t.state <- Normal
     | DCS ->
         (* Accumulate DCS payload until ESC \ (String Terminator) *)
-        if !pos < len then (
+        if !pos < len then
           let c = input.[!pos] in
           if c = '\027' && !pos + 1 < len && input.[!pos + 1] = '\\' then begin
             Buffer.add_string t.dcs_buf "\027\\" ;
@@ -210,10 +210,11 @@ let parse_core t ~emit_char input =
             emit_char (Buffer.contents t.dcs_buf) t.style ;
             t.state <- Normal ;
             pos := !pos + 2
-          end else begin
+          end
+          else begin
             Buffer.add_char t.dcs_buf c ;
             incr pos
-          end)
+          end
         else t.state <- Normal
     | CSI (params, current) ->
         if !pos < len then (

--- a/src/miaou_widgets_display/framebuffer_widget.ml
+++ b/src/miaou_widgets_display/framebuffer_widget.ml
@@ -124,18 +124,34 @@ let render_half_block t cols rows =
     for cx = 0 to cols - 1 do
       let r_top, g_top, b_top = get_rgb t cx (cy * 2) in
       let r_bot, g_bot, b_bot = get_rgb t cx ((cy * 2) + 1) in
-      if r_top = 0 && g_top = 0 && b_top = 0
-      && r_bot = 0 && g_bot = 0 && b_bot = 0 then
-        Buffer.add_char buf ' '
+      if
+        r_top = 0 && g_top = 0 && b_top = 0 && r_bot = 0 && g_bot = 0
+        && b_bot = 0
+      then Buffer.add_char buf ' '
       else begin
         (* Use fg=top (▀), bg=bottom — both as truecolor bg fills for solid rendering.
            When colors match, one bg+space suffices. Otherwise ▀ with fg+bg. *)
         if r_top = r_bot && g_top = g_bot && b_top = b_bot then
-          Buffer.add_string buf (Printf.sprintf "\027[48;2;%d;%d;%dm %s" r_top g_top b_top ansi_reset)
+          Buffer.add_string
+            buf
+            (Printf.sprintf
+               "\027[48;2;%d;%d;%dm %s"
+               r_top
+               g_top
+               b_top
+               ansi_reset)
         else
-          Buffer.add_string buf
-            (Printf.sprintf "\027[38;2;%d;%d;%dm\027[48;2;%d;%d;%dm\xE2\x96\x80%s"
-               r_top g_top b_top r_bot g_bot b_bot ansi_reset)
+          Buffer.add_string
+            buf
+            (Printf.sprintf
+               "\027[38;2;%d;%d;%dm\027[48;2;%d;%d;%dm\xE2\x96\x80%s"
+               r_top
+               g_top
+               b_top
+               r_bot
+               g_bot
+               b_bot
+               ansi_reset)
       end
     done
   done ;
@@ -149,7 +165,7 @@ let render_braille t cols rows =
     for cx = 0 to cols - 1 do
       for dy = 0 to 3 do
         for dx = 0 to 1 do
-          let px = cx * 2 + dx and py = cy * 4 + dy in
+          let px = (cx * 2) + dx and py = (cy * 4) + dy in
           if px < t.width_px && py < t.height_px then begin
             let r, g, b = get_rgb t px py in
             let luma = ((r * 299) + (g * 587) + (b * 114)) / 1000 in
@@ -236,7 +252,9 @@ let render_octant t cols rows =
               if r = 0 && g = 0 && b = 0 then Buffer.add_char buf ' '
               else
                 let idx = rgb_to_ansi_256 r g b in
-                Buffer.add_string buf (Printf.sprintf "\027[38;5;%dm%s%s" idx glyph ansi_reset)
+                Buffer.add_string
+                  buf
+                  (Printf.sprintf "\027[38;5;%dm%s%s" idx glyph ansi_reset)
             end
             else Buffer.add_char buf ' '
         | _ ->
@@ -338,7 +356,9 @@ let render_sextant t cols rows =
       | 0 ->
           if !bg_n > 0 then begin
             let r = !bg_r / !bg_n and g = !bg_g / !bg_n and b = !bg_b / !bg_n in
-            Buffer.add_string buf (Printf.sprintf "\027[48;2;%d;%d;%dm %s" r g b ansi_reset)
+            Buffer.add_string
+              buf
+              (Printf.sprintf "\027[48;2;%d;%d;%dm %s" r g b ansi_reset)
           end
           else Buffer.add_char buf ' '
       | 0x3F ->
@@ -347,7 +367,10 @@ let render_sextant t cols rows =
           if !fg_n > 0 then begin
             let r = !fg_r / !fg_n and g = !fg_g / !fg_n and b = !fg_b / !fg_n in
             if r = 0 && g = 0 && b = 0 then Buffer.add_char buf ' '
-            else Buffer.add_string buf (Printf.sprintf "\027[48;2;%d;%d;%dm %s" r g b ansi_reset)
+            else
+              Buffer.add_string
+                buf
+                (Printf.sprintf "\027[48;2;%d;%d;%dm %s" r g b ansi_reset)
           end
           else Buffer.add_char buf ' '
       | _ ->
@@ -400,23 +423,32 @@ let render_sixel t cols rows =
       let b = Char.code (Bytes.unsafe_get t.pixels (off + 2)) in
       if r <> 0 || g <> 0 || b <> 0 then begin
         let key = (r lsl 16) lor (g lsl 8) lor b in
-        let ci = match Hashtbl.find_opt palette_tbl key with
+        let ci =
+          match Hashtbl.find_opt palette_tbl key with
           | Some i -> i
           | None ->
-            if !n_colors >= 256 then begin
-              let best_i = ref 0 and best_d = ref max_int in
-              for i = 0 to !n_colors - 1 do
-                let pr, pg, pb = palette_rgb.(i) in
-                let d = (r-pr)*(r-pr) + (g-pg)*(g-pg) + (b-pb)*(b-pb) in
-                if d < !best_d then (best_d := d ; best_i := i)
-              done ;
-              !best_i
-            end else begin
-              let i = !n_colors in
-              Hashtbl.add palette_tbl key i ;
-              palette_rgb.(i) <- (r, g, b) ;
-              incr n_colors ; i
-            end
+              if !n_colors >= 256 then begin
+                let best_i = ref 0 and best_d = ref max_int in
+                for i = 0 to !n_colors - 1 do
+                  let pr, pg, pb = palette_rgb.(i) in
+                  let d =
+                    ((r - pr) * (r - pr))
+                    + ((g - pg) * (g - pg))
+                    + ((b - pb) * (b - pb))
+                  in
+                  if d < !best_d then (
+                    best_d := d ;
+                    best_i := i)
+                done ;
+                !best_i
+              end
+              else begin
+                let i = !n_colors in
+                Hashtbl.add palette_tbl key i ;
+                palette_rgb.(i) <- (r, g, b) ;
+                incr n_colors ;
+                i
+              end
         in
         idx_map.(row_off + px) <- ci
       end
@@ -426,8 +458,14 @@ let render_sixel t cols rows =
   (* Emit palette. *)
   for i = 0 to nc - 1 do
     let r, g, b = palette_rgb.(i) in
-    Buffer.add_string buf
-      (Printf.sprintf "#%d;2;%d;%d;%d" i (r*100/255) (g*100/255) (b*100/255))
+    Buffer.add_string
+      buf
+      (Printf.sprintf
+         "#%d;2;%d;%d;%d"
+         i
+         (r * 100 / 255)
+         (g * 100 / 255)
+         (b * 100 / 255))
   done ;
   (* Pass 2: single-pass per band — build all color patterns simultaneously,
      then emit only colors that appeared.  O(w × 6 × bands) instead of
@@ -439,7 +477,9 @@ let render_sixel t cols rows =
   let emit_rle pat count =
     let c = Char.chr (pat + 63) in
     if count <= 3 then
-      for _ = 1 to count do Buffer.add_char buf c done
+      for _ = 1 to count do
+        Buffer.add_char buf c
+      done
     else begin
       Buffer.add_char buf '!' ;
       Buffer.add_string buf (string_of_int count) ;

--- a/src/miaou_widgets_display/terminal_caps.ml
+++ b/src/miaou_widgets_display/terminal_caps.ml
@@ -29,8 +29,7 @@ let wezterm () =
 let kitty () =
   match Sys.getenv_opt "KITTY_WINDOW_ID" with Some _ -> true | _ -> false
 
-let konsole () =
-  Sys.getenv_opt "KONSOLE_VERSION" <> None
+let konsole () = Sys.getenv_opt "KONSOLE_VERSION" <> None
 
 (* Sixel: foot, WezTerm, kitty, iTerm2, Konsole (>=22.04) have reliable
    Sixel support. VTE-based terminals (GNOME Terminal, Terminator) technically
@@ -39,7 +38,8 @@ let konsole () =
 let detect_sixel () =
   let iterm =
     match Sys.getenv_opt "TERM_PROGRAM" with
-    | Some "iTerm.app" -> true | _ -> false
+    | Some "iTerm.app" -> true
+    | _ -> false
   in
   foot_terminal () || wezterm () || kitty () || konsole () || iterm
 

--- a/src/miaou_widgets_display/widgets.ml
+++ b/src/miaou_widgets_display/widgets.ml
@@ -154,29 +154,29 @@ let apply_bg_fill ~bg s =
      injected — return as-is. *)
   if has_pixel_proto s then s
   else
-  let prefix = "\027[" ^ Miaou_style.Style.bg_ansi_code bg ^ "m" in
-  let reset = Style.ansi_reset in
-  let len_s = String.length s in
-  let len_reset = String.length reset in
-  let rec find_sub start =
-    if start + len_reset > len_s then None
-    else if String.sub s start len_reset = reset then Some start
-    else find_sub (start + 1)
-  in
-  let buf = Buffer.create (len_s + 16) in
-  Buffer.add_string buf prefix ;
-  let rec loop i =
-    match find_sub i with
-    | None -> Buffer.add_string buf (String.sub s i (len_s - i))
-    | Some j ->
-        Buffer.add_string buf (String.sub s i (j - i)) ;
-        Buffer.add_string buf reset ;
-        Buffer.add_string buf prefix ;
-        loop (j + len_reset)
-  in
-  loop 0 ;
-  Buffer.add_string buf reset ;
-  Buffer.contents buf
+    let prefix = "\027[" ^ Miaou_style.Style.bg_ansi_code bg ^ "m" in
+    let reset = Style.ansi_reset in
+    let len_s = String.length s in
+    let len_reset = String.length reset in
+    let rec find_sub start =
+      if start + len_reset > len_s then None
+      else if String.sub s start len_reset = reset then Some start
+      else find_sub (start + 1)
+    in
+    let buf = Buffer.create (len_s + 16) in
+    Buffer.add_string buf prefix ;
+    let rec loop i =
+      match find_sub i with
+      | None -> Buffer.add_string buf (String.sub s i (len_s - i))
+      | Some j ->
+          Buffer.add_string buf (String.sub s i (j - i)) ;
+          Buffer.add_string buf reset ;
+          Buffer.add_string buf prefix ;
+          loop (j + len_reset)
+    in
+    loop 0 ;
+    Buffer.add_string buf reset ;
+    Buffer.contents buf
 
 (** Apply themed foreground color to text that has no foreground set.
     This ensures all text is visible regardless of terminal defaults.
@@ -193,8 +193,9 @@ let apply_themed_foreground content =
   let dark_mode = theme.Miaou_style.Theme.dark_mode in
   let resolved = Style.to_resolved ~dark_mode text_style in
   let fg = resolved.Style.r_fg in
-  if fg < 0 then content (* No text color in theme *)
-  (* Pixel protocol sequences (Sixel DCS, Kitty APC) must not have SGR codes
+  if fg < 0 then content
+    (* No text color in theme *)
+    (* Pixel protocol sequences (Sixel DCS, Kitty APC) must not have SGR codes
      injected into them.  Skip themed fg for any content that contains them. *)
   else if has_pixel_proto content then content
   else


### PR DESCRIPTION
## Summary

- Adds `PageUp`, `PageDown`, `Home`, and `End` variants to the `key` type in `input_parser.mli`
- Parses all standard terminal escape sequences for these keys:
  - `ESC [ 5 ~` → `PageUp`, `ESC [ 6 ~` → `PageDown`
  - `ESC [ H` / `ESC O H` / `ESC [ 1 ~` / `ESC [ 7 ~` → `Home`
  - `ESC [ F` / `ESC O F` / `ESC [ 4 ~` / `ESC [ 8 ~` → `End`
- All four keys are included in `is_nav_key` so they participate in the drain-on-repeat logic
- `bytes_for_key` returns `0` for the new keys (variable-length CSI sequences, consumed inline like `Mouse`)

## Test plan

- [ ] Build passes: `dune build @src/miaou_driver_common/all @src/miaou_driver_matrix/all @src/miaou_widgets_display/all`
- [ ] Key parsing: press PageUp/PageDown/Home/End in a terminal running miaou; verify `key_to_string` returns `"PageUp"` / `"PageDown"` / `"Home"` / `"End"`
- [ ] Works across terminal emulators that emit different escape sequences for these keys (xterm, VTE, rxvt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)