### PR TITLE
fix(matrix): invalidate dirty cells for full redraw

### DIFF
--- a/src/miaou_driver_matrix/matrix_buffer.ml
+++ b/src/miaou_driver_matrix/matrix_buffer.ml
@@ -110,20 +110,22 @@ let cell_changed t ~row ~col =
 
 let mark_all_dirty t =
   with_lock t (fun () ->
-      (* Clear front buffer so all cells appear changed *)
+      (* Invalidate front buffer so all cells appear changed.
+         Resetting to spaces would suppress blank writes and leave stale
+         terminal content behind. *)
       for r = 0 to t.rows - 1 do
         for c = 0 to t.cols - 1 do
-          Matrix_cell.reset t.front.(r).(c)
+          Matrix_cell.invalidate t.front.(r).(c)
         done
       done ;
       Atomic.set t.dirty true)
 
 let mark_region_dirty t ~row_start ~row_end ~col_start ~col_end =
   with_lock t (fun () ->
-      (* Clear front buffer region so those cells appear changed *)
+      (* Invalidate front buffer region so those cells appear changed. *)
       for r = max 0 row_start to min (t.rows - 1) row_end do
         for c = max 0 col_start to min (t.cols - 1) col_end do
-          Matrix_cell.reset t.front.(r).(c)
+          Matrix_cell.invalidate t.front.(r).(c)
         done
       done ;
       Atomic.set t.dirty true)

--- a/src/miaou_driver_matrix/matrix_buffer.mli
+++ b/src/miaou_driver_matrix/matrix_buffer.mli
@@ -69,10 +69,12 @@ val swap : t -> unit
 val cell_changed : t -> row:int -> col:int -> bool
 
 (** Mark all cells as needing redraw (for full refresh after resize).
+    Invalidates the front buffer so even blank cells are re-emitted.
     Thread-safe. *)
 val mark_all_dirty : t -> unit
 
 (** Mark a region of cells as needing redraw.
+    Invalidates the front buffer region so even blank cells are re-emitted.
     Thread-safe. Used for partial refresh and modal regions. *)
 val mark_region_dirty :
   t -> row_start:int -> row_end:int -> col_start:int -> col_end:int -> unit

--- a/test/test_matrix_diff.ml
+++ b/test/test_matrix_diff.ml
@@ -180,6 +180,23 @@ let test_unchanged_rows_skipped () =
   let changes = Diff.compute buf in
   check int "no changes for identical content" 0 (List.length changes)
 
+let test_mark_all_dirty_emits_clearing_spaces () =
+  let buf = Buffer.create ~rows:1 ~cols:5 in
+  Buffer.set_char buf ~row:0 ~col:0 ~char:"X" ~style:Cell.default_style ;
+  let _ = Diff.compute buf in
+  Buffer.swap buf ;
+
+  Buffer.clear_back buf ;
+  Buffer.mark_all_dirty buf ;
+  let changes = Diff.compute buf in
+  let writes_space =
+    List.exists
+      (function
+        | Diff.WriteChar " " | Diff.WriteRun (" ", _) -> true | _ -> false)
+      changes
+  in
+  check bool "full redraw emits clearing space" true writes_space
+
 (* Test with real ANSI file if it exists *)
 let test_real_ansi_file () =
   let file = "/tmp/miaou-modal-with-overlay.ansi" in
@@ -223,6 +240,10 @@ let () =
           test_case "write run optimization" `Quick test_write_run_optimization;
           test_case "diff positions" `Quick test_diff_positions;
           test_case "unchanged rows skipped" `Quick test_unchanged_rows_skipped;
+          test_case
+            "mark_all_dirty emits clearing spaces"
+            `Quick
+            test_mark_all_dirty_emits_clearing_spaces;
         ] );
       ( "modal",
         [


### PR DESCRIPTION
Closes #140.

## Summary
- invalidate Matrix front-buffer cells for full redraw/dirty-region paths instead of resetting them to valid blank cells
- document why invalidation is required for blank-cell redraws
- add a regression test proving full redraw emits clearing spaces

## Tests
- dune fmt
- dune build
- dune exec test/test_matrix_diff.exe

## Notes
- No CHANGELOG entry in this branch to keep the six independent bugfix PRs conflict-free; a single rollup changelog entry can be added after merge.