### PR TITLE
fix(matrix): account for wide unicode cells

### DIFF
--- a/src/miaou_driver_matrix/matrix_ansi_parser.ml
+++ b/src/miaou_driver_matrix/matrix_ansi_parser.ml
@@ -115,6 +115,8 @@ let extract_utf8_char s pos =
     let len = min len (String.length s - pos) in
     (String.sub s pos len, len)
 
+let cell_width char = max 0 (Miaou_helpers.Helpers.visible_chars_count char)
+
 (* Process a completed OSC sequence payload.
    For OSC 8 (hyperlinks): "8;params;uri" — extract the URI and update style.
    Empty URI closes the current hyperlink. *)
@@ -248,9 +250,31 @@ let parse_core t ~emit_char input =
 (* Parse a single line into a buffer at given row/col *)
 let parse_line t buf ~row ~col input =
   let col = ref col in
+  let cols = Matrix_buffer.cols buf in
   let emit_char char style =
-    Matrix_buffer.set_char buf ~row ~col:!col ~char ~style ;
-    incr col
+    let width = cell_width char in
+    if width > 0 then begin
+      let remaining = cols - !col in
+      if width <= remaining then begin
+        Matrix_buffer.set_char buf ~row ~col:!col ~char ~style ;
+        for offset = 1 to width - 1 do
+          Matrix_buffer.set_char buf ~row ~col:(!col + offset) ~char:" " ~style
+        done ;
+        col := !col + width
+      end
+      else begin
+        if remaining > 0 then
+          for offset = 0 to remaining - 1 do
+            Matrix_buffer.set_char
+              buf
+              ~row
+              ~col:(!col + offset)
+              ~char:" "
+              ~style
+          done ;
+        col := cols
+      end
+    end
   in
   let _ = parse_core t ~emit_char input in
   !col
@@ -274,8 +298,24 @@ let parse_into t buf ~row ~col input =
 let parse_line_batch t (ops : Matrix_buffer.batch_ops) ~row ~col input =
   let col = ref col in
   let emit_char char style =
-    ops.set_char ~row ~col:!col ~char ~style ;
-    incr col
+    let width = cell_width char in
+    if width > 0 then begin
+      let remaining = ops.cols - !col in
+      if width <= remaining then begin
+        ops.set_char ~row ~col:!col ~char ~style ;
+        for offset = 1 to width - 1 do
+          ops.set_char ~row ~col:(!col + offset) ~char:" " ~style
+        done ;
+        col := !col + width
+      end
+      else begin
+        if remaining > 0 then
+          for offset = 0 to remaining - 1 do
+            ops.set_char ~row ~col:(!col + offset) ~char:" " ~style
+          done ;
+        col := ops.cols
+      end
+    end
   in
   let _ = parse_core t ~emit_char input in
   !col
@@ -350,7 +390,9 @@ let visible_length input =
     else if c = '\n' || c = '\r' then incr pos
     else begin
       let char_len = utf8_char_length c in
-      incr count ;
+      let char_len = min char_len (len - !pos) in
+      let char = String.sub input !pos char_len in
+      count := !count + cell_width char ;
       pos := !pos + char_len
     end
   done ;

--- a/test/test_matrix_ansi_parser.ml
+++ b/test/test_matrix_ansi_parser.ml
@@ -65,11 +65,28 @@ let test_utf8_mixed () =
   check string "cell 1" "★" (get_char buf 0 1) ;
   check string "cell 2" "B" (get_char buf 0 2)
 
+let test_utf8_wide_char_advances_two_cells () =
+  let buf, parser = make_test_env ~rows:1 ~cols:20 in
+  let col = Parser.parse_line parser buf ~row:0 ~col:0 "界X" in
+  check int "wide char plus ascii advances 3 cols" 3 col ;
+  check string "wide char at col 0" "界" (get_char buf 0 0) ;
+  check string "placeholder at col 1" " " (get_char buf 0 1) ;
+  check string "ascii after wide char at col 2" "X" (get_char buf 0 2)
+
+let test_utf8_wide_char_clipped_at_right_edge () =
+  let buf, parser = make_test_env ~rows:1 ~cols:2 in
+  Buffer.set_char buf ~row:0 ~col:1 ~char:"X" ~style:Cell.default_style ;
+  let col = Parser.parse_line parser buf ~row:0 ~col:1 "界" in
+  check int "clipped wide char advances to edge" 2 col ;
+  check string "edge cell is cleared" " " (get_char buf 0 1)
+
 let test_utf8_emoji () =
   let buf, parser = make_test_env ~rows:1 ~cols:20 in
-  let col = Parser.parse_line parser buf ~row:0 ~col:0 "🐱" in
-  check int "advances 1" 1 col ;
-  check string "cat emoji" "🐱" (get_char buf 0 0)
+  let col = Parser.parse_line parser buf ~row:0 ~col:0 "🐱X" in
+  check int "emoji plus ascii advances 3 cols" 3 col ;
+  check string "cat emoji" "🐱" (get_char buf 0 0) ;
+  check string "emoji placeholder" " " (get_char buf 0 1) ;
+  check string "ascii after emoji" "X" (get_char buf 0 2)
 
 let test_utf8_accents () =
   let buf, parser = make_test_env ~rows:1 ~cols:20 in
@@ -235,6 +252,10 @@ let test_visible_length_utf8 () =
   let len = Parser.visible_length "★ Star" in
   check int "utf8 6" 6 len
 
+let test_visible_length_wide_utf8 () =
+  let len = Parser.visible_length "界X" in
+  check int "wide utf8 3" 3 len
+
 (* ============== OSC Sequence Tests ============== *)
 
 let test_osc8_hyperlink_skipped () =
@@ -354,6 +375,14 @@ let utf8_tests =
   [
     test_case "utf8 simple" `Quick test_utf8_simple;
     test_case "utf8 mixed" `Quick test_utf8_mixed;
+    test_case
+      "utf8 wide char advances two cells"
+      `Quick
+      test_utf8_wide_char_advances_two_cells;
+    test_case
+      "utf8 wide char clipped at right edge"
+      `Quick
+      test_utf8_wide_char_clipped_at_right_edge;
     test_case "utf8 emoji" `Quick test_utf8_emoji;
     test_case "utf8 accents" `Quick test_utf8_accents;
   ]
@@ -399,6 +428,7 @@ let visible_length_tests =
     test_case "visible length with ansi" `Quick test_visible_length_with_ansi;
     test_case "visible length complex" `Quick test_visible_length_complex;
     test_case "visible length utf8" `Quick test_visible_length_utf8;
+    test_case "visible length wide utf8" `Quick test_visible_length_wide_utf8;
   ]
 
 let osc_tests =


### PR DESCRIPTION
Closes #142.

## Summary
- make Matrix ANSI parsing advance by terminal display width rather than one cell per UTF-8 sequence
- reserve continuation cells for wide glyphs so following text lands in the correct column
- update Matrix visible-length handling and tests for CJK/emoji width

## Tests
- dune fmt
- dune build
- dune exec test/test_matrix_ansi_parser.exe

## Notes
- No CHANGELOG entry in this branch to keep the six independent bugfix PRs conflict-free; a single rollup changelog entry can be added after merge.