### PR TITLE
fix(input): preserve utf8 characters while editing

### DIFF
--- a/src/miaou_driver_common/input_parser.ml
+++ b/src/miaou_driver_common/input_parser.ml
@@ -47,6 +47,22 @@ let tab_code = 9
 
 let backspace_code = 127
 
+let utf8_char_length c =
+  let code = Char.code c in
+  if code land 0x80 = 0 then 1
+  else if code land 0xE0 = 0xC0 then 2
+  else if code land 0xF0 = 0xE0 then 3
+  else if code land 0xF8 = 0xF0 then 4
+  else 1
+
+let utf8_complete_char pending =
+  if String.length pending = 0 then None
+  else
+    let first = pending.[0] in
+    let needed = utf8_char_length first in
+    if String.length pending < needed then None
+    else Some (String.sub pending 0 needed)
+
 (** Read bytes into buffer with timeout. Returns bytes read. *)
 let refill t ~timeout_s =
   try
@@ -122,7 +138,10 @@ let peek_key t =
       else if code >= 1 && code <= 26 then
         let letter = Char.chr (code + 96) in
         Some (Ctrl letter)
-      else Some (Char (String.make 1 first))
+      else
+        match utf8_complete_char t.pending with
+        | Some s -> Some (Char s)
+        | None -> None
     else
       (* ESC sequence - need at least 3 chars for complete arrow keys *)
       let len = String.length t.pending in
@@ -201,16 +220,40 @@ let parse_key t =
     let first = String.get t.pending 0 in
     let code = Char.code first in
     if code <> esc_code then begin
-      (* Simple non-ESC key - consume 1 byte *)
-      consume t 1 ;
-      if first = '\000' then Some Refresh
-      else if first = '\n' || first = '\r' then Some Enter
-      else if code = tab_code then Some Tab
-      else if code = backspace_code then Some Backspace
-      else if code >= 1 && code <= 26 then
+      (* Simple non-ESC key. ASCII controls consume one byte; printable UTF-8
+         input consumes the full encoded character. *)
+      if first = '\000' then (
+        consume t 1 ;
+        Some Refresh)
+      else if first = '\n' || first = '\r' then (
+        consume t 1 ;
+        Some Enter)
+      else if code = tab_code then (
+        consume t 1 ;
+        Some Tab)
+      else if code = backspace_code then (
+        consume t 1 ;
+        Some Backspace)
+      else if code >= 1 && code <= 26 then (
+        consume t 1 ;
         let letter = Char.chr (code + 96) in
-        Some (Ctrl letter)
-      else Some (Char (String.make 1 first))
+        Some (Ctrl letter))
+      else
+        let needed = utf8_char_length first in
+        let rec wait n =
+          if n <= 0 || String.length t.pending >= needed then ()
+          else (
+            ignore (refill t ~timeout_s:0.02) ;
+            wait (n - 1))
+        in
+        wait 5 ;
+        let char =
+          match utf8_complete_char t.pending with
+          | Some s -> s
+          | None -> String.make 1 first
+        in
+        consume t (String.length char) ;
+        Some (Char char)
     end
     else begin
       (* ESC sequence - gather more bytes if needed *)

--- a/src/miaou_helpers/helpers.ml
+++ b/src/miaou_helpers/helpers.ml
@@ -50,6 +50,35 @@ let utf8_decode s i =
       (((byte land 0x07) lsl 18) lor (b1 lsl 12) lor (b2 lsl 6) lor b3, i + 4)
     else (byte, i + 1)
 
+let utf8_prev_boundary s i =
+  let len = String.length s in
+  let j = ref (max 0 (min len i) - 1) in
+  while !j > 0 && not (is_utf8_lead s.[!j]) do
+    decr j
+  done ;
+  max 0 !j
+
+let utf8_next_boundary s i =
+  let len = String.length s in
+  let i = max 0 (min len i) in
+  if i >= len then len
+  else
+    let rec find_lead j =
+      if j >= len then len
+      else if is_utf8_lead s.[j] then j
+      else find_lead (j + 1)
+    in
+    let start = if is_utf8_lead s.[i] then i else find_lead (i + 1) in
+    if start >= len then len
+    else
+      let _, next = utf8_decode s start in
+      min len next
+
+let utf8_clamp_boundary s i =
+  let len = String.length s in
+  let i = max 0 (min len i) in
+  if i = len || i = 0 || is_utf8_lead s.[i] then i else utf8_prev_boundary s i
+
 let is_wide cp =
   (cp >= 0x1100 && cp <= 0x115F)
   || (cp >= 0x2329 && cp <= 0x232A)

--- a/src/miaou_helpers/helpers.mli
+++ b/src/miaou_helpers/helpers.mli
@@ -7,6 +7,12 @@
 
 val is_utf8_lead : char -> bool
 
+val utf8_prev_boundary : string -> int -> int
+
+val utf8_next_boundary : string -> int -> int
+
+val utf8_clamp_boundary : string -> int -> int
+
 val is_esc_start : string -> int -> bool
 
 val is_osc_start : string -> int -> bool

--- a/src/miaou_widgets_input/textarea_widget.ml
+++ b/src/miaou_widgets_input/textarea_widget.ml
@@ -9,6 +9,7 @@
 (** Multiline text input widget with cursor and scroll support. *)
 
 open Miaou_widgets_display.Widgets
+module H = Miaou_helpers.Helpers
 
 type edit_op = No_edit | Char_insert | Other_edit
 
@@ -92,6 +93,36 @@ let can_undo t = t.undo_stack <> []
 
 let can_redo t = t.redo_stack <> []
 
+let clamp_col line col = H.utf8_clamp_boundary line col
+
+let line_len t row = String.length t.lines.(row)
+
+let clamp_to_line t row col = clamp_col t.lines.(row) (min col (line_len t row))
+
+let is_named_non_text_key = function
+  | "Tab" | "S-Tab" | "Shift-Tab" | "BackTab" | "Enter" | "A-Enter"
+  | "Alt-Enter" | "Backspace" | "Delete" | "Left" | "Right" | "Up" | "Down"
+  | "Home" | "End" | "Esc" | "Escape" | "PageUp" | "PageDown" | "WheelUp"
+  | "WheelDown" ->
+      true
+  | key when String.length key >= 2 && String.sub key 0 2 = "C-" -> true
+  | key when String.length key >= 2 && key.[0] = 'F' -> (
+      match int_of_string_opt (String.sub key 1 (String.length key - 1)) with
+      | Some _ -> true
+      | None -> false)
+  | key when Miaou_helpers.Mouse.is_click key || Miaou_helpers.Mouse.is_drag key
+    ->
+      true
+  | _ -> false
+
+let is_text_key key =
+  key <> ""
+  && (not (is_named_non_text_key key))
+  && not
+       (String.exists
+          (fun c -> c = '\027' || c = '\000' || c = '\n' || c = '\r')
+          key)
+
 let create ?title ?(width = 60) ?(height = 10) ?(initial = "") ?placeholder () =
   let lines =
     if String.length initial = 0 then [|""|]
@@ -130,10 +161,9 @@ let set_current_line t content =
 (** Insert a new line at cursor position *)
 let insert_newline t =
   let line = current_line t in
-  let left = String.sub line 0 t.cursor_col in
-  let right =
-    String.sub line t.cursor_col (String.length line - t.cursor_col)
-  in
+  let cursor_col = clamp_col line t.cursor_col in
+  let left = String.sub line 0 cursor_col in
+  let right = String.sub line cursor_col (String.length line - cursor_col) in
   let before = Array.sub t.lines 0 t.cursor_row in
   let after =
     Array.sub
@@ -160,11 +190,11 @@ let insert_newline t =
 let backspace t =
   if t.cursor_col > 0 then
     let line = current_line t in
-    let left = String.sub line 0 (t.cursor_col - 1) in
-    let right =
-      String.sub line t.cursor_col (String.length line - t.cursor_col)
-    in
-    set_current_line {t with cursor_col = t.cursor_col - 1} (left ^ right)
+    let cursor_col = clamp_col line t.cursor_col in
+    let prev = H.utf8_prev_boundary line cursor_col in
+    let left = String.sub line 0 prev in
+    let right = String.sub line cursor_col (String.length line - cursor_col) in
+    set_current_line {t with cursor_col = prev} (left ^ right)
   else if t.cursor_row > 0 then
     (* Join with previous line *)
     let prev_line = t.lines.(t.cursor_row - 1) in
@@ -195,11 +225,11 @@ let backspace t =
 (** Delete character at cursor (delete key) *)
 let delete t =
   let line = current_line t in
-  if t.cursor_col < String.length line then
-    let left = String.sub line 0 t.cursor_col in
-    let right =
-      String.sub line (t.cursor_col + 1) (String.length line - t.cursor_col - 1)
-    in
+  let cursor_col = clamp_col line t.cursor_col in
+  if cursor_col < String.length line then
+    let next = H.utf8_next_boundary line cursor_col in
+    let left = String.sub line 0 cursor_col in
+    let right = String.sub line next (String.length line - next) in
     set_current_line t (left ^ right)
   else if t.cursor_row < Array.length t.lines - 1 then
     (* Join with next line *)
@@ -218,15 +248,17 @@ let delete t =
 (** Insert character at cursor *)
 let insert_char t ch =
   let line = current_line t in
-  let left = String.sub line 0 t.cursor_col in
-  let right =
-    String.sub line t.cursor_col (String.length line - t.cursor_col)
-  in
-  set_current_line {t with cursor_col = t.cursor_col + 1} (left ^ ch ^ right)
+  let cursor_col = clamp_col line t.cursor_col in
+  let left = String.sub line 0 cursor_col in
+  let right = String.sub line cursor_col (String.length line - cursor_col) in
+  set_current_line
+    {t with cursor_col = cursor_col + String.length ch}
+    (left ^ ch ^ right)
 
 (** Move cursor left *)
 let move_left t =
-  if t.cursor_col > 0 then {t with cursor_col = t.cursor_col - 1}
+  if t.cursor_col > 0 then
+    {t with cursor_col = H.utf8_prev_boundary (current_line t) t.cursor_col}
   else if t.cursor_row > 0 then
     let new_row = t.cursor_row - 1 in
     let scroll_offset =
@@ -245,7 +277,7 @@ let move_left t =
 let move_right t =
   let line = current_line t in
   if t.cursor_col < String.length line then
-    {t with cursor_col = t.cursor_col + 1}
+    {t with cursor_col = H.utf8_next_boundary line t.cursor_col}
   else if t.cursor_row < Array.length t.lines - 1 then
     let new_row = t.cursor_row + 1 in
     let scroll_offset =
@@ -259,7 +291,7 @@ let move_right t =
 let move_up t =
   if t.cursor_row > 0 then
     let new_row = t.cursor_row - 1 in
-    let new_col = min t.cursor_col (String.length t.lines.(new_row)) in
+    let new_col = clamp_to_line t new_row t.cursor_col in
     let scroll_offset =
       if new_row < t.scroll_offset then max 0 (t.scroll_offset - 1)
       else t.scroll_offset
@@ -271,7 +303,7 @@ let move_up t =
 let move_down t =
   if t.cursor_row < Array.length t.lines - 1 then
     let new_row = t.cursor_row + 1 in
-    let new_col = min t.cursor_col (String.length t.lines.(new_row)) in
+    let new_col = clamp_to_line t new_row t.cursor_col in
     let scroll_offset =
       if new_row >= t.scroll_offset + t.height then t.scroll_offset + 1
       else t.scroll_offset
@@ -312,12 +344,11 @@ let render t ~focus:(_ : bool) =
         let line = t.lines.(line_idx) in
         if line_idx = t.cursor_row then
           (* Show cursor *)
-          let left =
-            String.sub line 0 (min t.cursor_col (String.length line))
-          in
+          let cursor_col = clamp_col line t.cursor_col in
+          let left = String.sub line 0 cursor_col in
           let right =
-            if t.cursor_col < String.length line then
-              String.sub line t.cursor_col (String.length line - t.cursor_col)
+            if cursor_col < String.length line then
+              String.sub line cursor_col (String.length line - cursor_col)
             else ""
           in
           left ^ "_" ^ right
@@ -382,7 +413,7 @@ let on_key t ~key =
         min max_scroll (t.scroll_offset + Miaou_helpers.Mouse.wheel_scroll_lines)
       in
       ({t with scroll_offset = new_scroll}, Handled)
-  | k when String.length k = 1 ->
+  | k when is_text_key k ->
       (edit ~op:Char_insert (fun t -> insert_char t k), Handled)
   | key -> (
       (* Check for mouse click to position cursor *)
@@ -394,8 +425,9 @@ let on_key t ~key =
           (* 1 for left border *)
           let max_row = Array.length t.lines - 1 in
           let new_row = max 0 (min max_row text_row) in
-          let max_col = String.length t.lines.(new_row) in
-          let new_col = max 0 (min max_col text_col) in
+          let new_col =
+            H.visible_byte_index_of_pos t.lines.(new_row) (max 0 text_col)
+          in
           ({t with cursor_row = new_row; cursor_col = new_col}, Handled)
       | None -> (t, Bubble))
 
@@ -415,7 +447,7 @@ let set_text t s =
     else Array.of_list (String.split_on_char '\n' s)
   in
   let cursor_row = min t.cursor_row (Array.length lines - 1) in
-  let cursor_col = min t.cursor_col (String.length lines.(cursor_row)) in
+  let cursor_col = clamp_col lines.(cursor_row) t.cursor_col in
   {t with lines; cursor_row; cursor_col}
 
 let is_cancelled t = t.cancelled

--- a/src/miaou_widgets_input/textarea_widget.mli
+++ b/src/miaou_widgets_input/textarea_widget.mli
@@ -133,7 +133,8 @@ val is_cancelled : t -> bool
 (** Clear the cancelled flag. *)
 val reset_cancelled : t -> t
 
-(** Get cursor position as [(row, col)] (0-indexed). *)
+(** Get cursor position as [(row, col)] (0-indexed), where [col] is a UTF-8
+    boundary byte offset in the current line. *)
 val cursor_position : t -> int * int
 
 (** Get total number of lines. *)

--- a/src/miaou_widgets_input/textbox_widget.ml
+++ b/src/miaou_widgets_input/textbox_widget.ml
@@ -10,13 +10,56 @@ open Miaou_widgets_display.Widgets
 
 type t = {
   buf : string;
-  cursor : int; (* index in characters *)
+  cursor : int; (* UTF-8 boundary byte offset *)
   title : string option;
   width : int;
   cancelled : bool;
   placeholder : string option;
   mask : bool;
 }
+
+module H = Miaou_helpers.Helpers
+
+let clamp_cursor s cursor = H.utf8_clamp_boundary s cursor
+
+let utf8_char_count_until s cursor =
+  let cursor = clamp_cursor s cursor in
+  let rec loop i count =
+    if i >= cursor then count
+    else
+      let next = H.utf8_next_boundary s i in
+      if next <= i then count else loop next (count + 1)
+  in
+  loop 0 0
+
+let masked_display_and_cursor s cursor =
+  let char_count = utf8_char_count_until s (String.length s) in
+  let cursor = utf8_char_count_until s cursor in
+  (String.make char_count '*', cursor)
+
+let is_named_non_text_key = function
+  | "Tab" | "S-Tab" | "Shift-Tab" | "BackTab" | "Enter" | "A-Enter"
+  | "Alt-Enter" | "Backspace" | "Delete" | "Left" | "Right" | "Up" | "Down"
+  | "Home" | "End" | "Esc" | "Escape" | "PageUp" | "PageDown" | "WheelUp"
+  | "WheelDown" ->
+      true
+  | key when String.length key >= 2 && String.sub key 0 2 = "C-" -> true
+  | key when String.length key >= 2 && key.[0] = 'F' -> (
+      match int_of_string_opt (String.sub key 1 (String.length key - 1)) with
+      | Some _ -> true
+      | None -> false)
+  | key when Miaou_helpers.Mouse.is_click key || Miaou_helpers.Mouse.is_drag key
+    ->
+      true
+  | _ -> false
+
+let is_text_key key =
+  key <> ""
+  && (not (is_named_non_text_key key))
+  && not
+       (String.exists
+          (fun c -> c = '\027' || c = '\000' || c = '\n' || c = '\r')
+          key)
 
 let create ?title ?(width = 60) ?(initial = "") ?(placeholder = None)
     ?(mask = false) () =
@@ -47,13 +90,14 @@ let render st ~focus:(_ : bool) =
   let with_cursor =
     if show_placeholder then (* dim placeholder *) themed_muted visible
     else
-      let display =
-        if st.mask then String.make (String.length content) '*' else content
+      let display, cursor =
+        if st.mask then masked_display_and_cursor content st.cursor
+        else (content, clamp_cursor content st.cursor)
       in
-      let left = String.sub display 0 (min st.cursor (String.length display)) in
+      let left = String.sub display 0 cursor in
       let right =
-        if st.cursor < String.length display then
-          String.sub display st.cursor (String.length display - st.cursor)
+        if cursor < String.length display then
+          String.sub display cursor (String.length display - cursor)
         else ""
       in
       themed_text (left ^ "_" ^ right)
@@ -73,42 +117,49 @@ let on_key st ~key =
   | "Backspace" ->
       if st.cursor > 0 then
         let s = st.buf in
-        let left = String.sub s 0 (st.cursor - 1) in
-        let right = String.sub s st.cursor (String.length s - st.cursor) in
-        ({st with buf = left ^ right; cursor = st.cursor - 1}, Handled)
+        let cursor = clamp_cursor s st.cursor in
+        let prev = H.utf8_prev_boundary s cursor in
+        let left = String.sub s 0 prev in
+        let right = String.sub s cursor (String.length s - cursor) in
+        ({st with buf = left ^ right; cursor = prev}, Handled)
       else (st, Handled) (* Consumed even if no-op *)
   | "Delete" ->
       let s = st.buf in
-      if st.cursor < String.length s then
-        let left = String.sub s 0 st.cursor in
-        let right =
-          String.sub s (st.cursor + 1) (String.length s - st.cursor - 1)
-        in
+      let cursor = clamp_cursor s st.cursor in
+      if cursor < String.length s then
+        let next = H.utf8_next_boundary s cursor in
+        let left = String.sub s 0 cursor in
+        let right = String.sub s next (String.length s - next) in
         ({st with buf = left ^ right}, Handled)
       else (st, Handled)
       (* Consumed even if no-op *)
   | "Left" ->
-      if st.cursor > 0 then ({st with cursor = st.cursor - 1}, Handled)
+      if st.cursor > 0 then
+        ({st with cursor = H.utf8_prev_boundary st.buf st.cursor}, Handled)
       else (st, Handled)
   | "Right" ->
       if st.cursor < String.length st.buf then
-        ({st with cursor = st.cursor + 1}, Handled)
+        ({st with cursor = H.utf8_next_boundary st.buf st.cursor}, Handled)
       else (st, Handled)
   | "Home" -> ({st with cursor = 0}, Handled)
   | "End" -> ({st with cursor = String.length st.buf}, Handled)
   | "Esc" | "Escape" -> ({st with cancelled = true}, Handled)
-  | k when String.length k = 1 ->
+  | k when is_text_key k ->
       let s = st.buf in
-      let left = String.sub s 0 st.cursor in
-      let right = String.sub s st.cursor (String.length s - st.cursor) in
-      ({st with buf = left ^ k ^ right; cursor = st.cursor + 1}, Handled)
+      let cursor = clamp_cursor s st.cursor in
+      let left = String.sub s 0 cursor in
+      let right = String.sub s cursor (String.length s - cursor) in
+      ( {st with buf = left ^ k ^ right; cursor = cursor + String.length k},
+        Handled )
   | key -> (
       (* Check for mouse click to position cursor *)
       match Miaou_helpers.Mouse.parse_click key with
       | Some {col; _} ->
           (* Account for "[" prefix (1 char) *)
           let text_col = col - 1 in
-          let new_cursor = max 0 (min (String.length st.buf) text_col) in
+          let new_cursor =
+            H.visible_byte_index_of_pos st.buf (max 0 text_col)
+          in
           ({st with cursor = new_cursor}, Handled)
       | None -> (st, Bubble))
 
@@ -128,10 +179,10 @@ let get_text t = value t
 (* Reference get_text to avoid unused-value warning when it's only used by modal on_close handlers *)
 let () = ignore (get_text : t -> string)
 
-let set_text t s = {t with buf = s; cursor = min (String.length s) t.cursor}
+let set_text t s = {t with buf = s; cursor = clamp_cursor s t.cursor}
 
 let set_text_with_cursor t ~text ~cursor =
-  let c = max 0 (min (String.length text) cursor) in
+  let c = clamp_cursor text cursor in
   {t with buf = text; cursor = c}
 
 let cursor t = t.cursor

--- a/src/miaou_widgets_input/textbox_widget.mli
+++ b/src/miaou_widgets_input/textbox_widget.mli
@@ -132,7 +132,8 @@ val value : t -> string
 val set_text : t -> string -> t
 
 (** Set both text and cursor position explicitly.
-    The cursor position is clamped to the valid range [0, String.length text]. *)
+    The cursor position is clamped to the valid range [0, String.length text]
+    and to a valid UTF-8 character boundary. *)
 val set_text_with_cursor : t -> text:string -> cursor:int -> t
 
 (** {1 State Queries} *)
@@ -145,7 +146,7 @@ val is_cancelled : t -> bool
 (** Clear the cancelled flag. *)
 val reset_cancelled : t -> t
 
-(** Get the current cursor position (character index). *)
+(** Get the current cursor position as a UTF-8 boundary byte offset. *)
 val cursor : t -> int
 
 (** Get the display width of the textbox. *)

--- a/test/test_input_parser.ml
+++ b/test/test_input_parser.ml
@@ -250,6 +250,26 @@ let test_parse_sequence () =
   | _ -> fail "Expected None after buffer empty") ;
   cleanup (p, r)
 
+let test_parse_utf8_characters () =
+  let cases = ["é"; "界"; "🐱"] in
+  List.iter
+    (fun input ->
+      let p, r = parser_with_input input in
+      (match Parser.parse_key p with
+      | Some (Parser.Char s) when s = input -> ()
+      | Some (Parser.Char s) ->
+          fail
+            (Printf.sprintf "Expected one UTF-8 character %S, got %S" input s)
+      | Some k ->
+          fail
+            (Printf.sprintf
+               "Expected UTF-8 Char, got %s"
+               (Parser.key_to_string k))
+      | None -> fail "Expected UTF-8 Char") ;
+      check int "buffer empty after utf8 char" 0 (Parser.pending_length p) ;
+      cleanup (p, r))
+    cases
+
 (* Test SGR mouse parsing *)
 let test_parse_mouse_sgr () =
   (* SGR mouse release: ESC [ < 0;10;5m *)
@@ -497,6 +517,7 @@ let () =
           test_case "escape" `Quick test_parse_escape;
           test_case "escape unknown pair" `Quick test_parse_escape_unknown_pair;
           test_case "sequence" `Quick test_parse_sequence;
+          test_case "utf8 characters" `Quick test_parse_utf8_characters;
           test_case "mouse sgr" `Quick test_parse_mouse_sgr;
           test_case "mouse wheel" `Quick test_parse_mouse_wheel;
           test_case "mouse drag" `Quick test_parse_mouse_drag;

--- a/test/test_textarea_undo.ml
+++ b/test/test_textarea_undo.ml
@@ -51,6 +51,17 @@ let test_backspace_separate_step () =
   let t = key t "C-z" in
   check string "undo restores backspace" "ab" (TA.get_text t)
 
+let test_utf8_editing () =
+  let t = TA.create ~initial:"é界🐱" () in
+  let t = key t "Backspace" in
+  check string "backspace removes emoji" "é界" (TA.get_text t) ;
+  let t = key t "Left" in
+  let t = key t "Delete" in
+  check string "delete removes CJK char" "é" (TA.get_text t) ;
+  let t = key t "Home" in
+  let t = key t "🐱" in
+  check string "insert emoji at start" "🐱é" (TA.get_text t)
+
 let test_new_edit_clears_redo () =
   let t = TA.create () in
   let t = type_chars t "abc" in
@@ -82,6 +93,7 @@ let () =
             "backspace is its own step"
             `Quick
             test_backspace_separate_step;
+          test_case "utf8 editing" `Quick test_utf8_editing;
           test_case "new edit clears redo" `Quick test_new_edit_clears_redo;
           test_case
             "undo no-op when stack empty"

--- a/test/test_textbox_more.ml
+++ b/test/test_textbox_more.ml
@@ -1,6 +1,16 @@
 open Alcotest
 module TB = Miaou_widgets_input.Textbox_widget
 
+let contains_substring s sub =
+  let len = String.length s in
+  let sub_len = String.length sub in
+  let rec loop i =
+    if i + sub_len > len then false
+    else if String.sub s i sub_len = sub then true
+    else loop (i + 1)
+  in
+  sub_len = 0 || loop 0
+
 let test_editing () =
   let tb = TB.create ~initial:"abc" ~width:10 () in
   let tb = TB.handle_key tb ~key:"Left" in
@@ -23,7 +33,39 @@ let test_editing () =
   let tb = TB.with_width tb 3 in
   check int "width clamp" 4 (TB.width tb)
 
+let test_utf8_editing () =
+  let tb = TB.create ~initial:"é界🐱" ~width:20 () in
+  let tb = TB.handle_key tb ~key:"Backspace" in
+  check string "backspace removes emoji" "é界" (TB.value tb) ;
+  let tb = TB.handle_key tb ~key:"Left" in
+  let tb = TB.handle_key tb ~key:"Delete" in
+  check string "delete removes CJK char" "é" (TB.value tb) ;
+  let tb = TB.handle_key tb ~key:"Home" in
+  let tb = TB.handle_key tb ~key:"🐱" in
+  check string "insert emoji at start" "🐱é" (TB.value tb)
+
+let test_masked_utf8_rendering () =
+  let tb = TB.create ~initial:"é界🐱" ~mask:true ~width:20 () in
+  let rendered = TB.render tb ~focus:true in
+  check
+    bool
+    "one mask per utf8 character"
+    true
+    (contains_substring rendered "***_") ;
+  check
+    bool
+    "not one mask per byte"
+    false
+    (contains_substring rendered "*********_")
+
 let () =
   run
     "textbox_more"
-    [("textbox_more", [test_case "editing" `Quick test_editing])]
+    [
+      ( "textbox_more",
+        [
+          test_case "editing" `Quick test_editing;
+          test_case "utf8 editing" `Quick test_utf8_editing;
+          test_case "masked utf8 rendering" `Quick test_masked_utf8_rendering;
+        ] );
+    ]


### PR DESCRIPTION
Closes #141.

## Summary
- decode full UTF-8 sequences in the shared terminal input parser
- add UTF-8 boundary helpers for byte-offset cursors
- keep textbox and textarea edits on valid UTF-8 boundaries for insert/delete/backspace/movement
- add parser, textbox, and textarea UTF-8 regression tests

## Tests
- dune fmt
- dune build
- dune exec test/test_input_parser.exe
- dune exec test/test_textbox_more.exe
- dune exec test/test_textarea_undo.exe

## Notes
- No CHANGELOG entry in this branch to keep the six independent bugfix PRs conflict-free; a single rollup changelog entry can be added after merge.