### PR TITLE
fix(widgets): sanitize osc8 hyperlink urls

### DIFF
--- a/src/miaou_driver_matrix/matrix_ansi_writer.ml
+++ b/src/miaou_driver_matrix/matrix_ansi_writer.ml
@@ -79,15 +79,18 @@ let render t changes =
       | Matrix_diff.SetStyle style ->
           if not (Matrix_cell.style_equal style t.current_style) then begin
             (* Handle OSC 8 hyperlink changes *)
-            if not (String.equal style.url t.current_url) then begin
+            let sanitized_url =
+              Miaou_helpers.Helpers.sanitize_osc_payload style.url
+            in
+            if not (String.equal sanitized_url t.current_url) then begin
               (* Close current hyperlink if active *)
               if t.current_url <> "" then Buffer.add_string buf "\027]8;;\027\\" ;
               (* Open new hyperlink if needed *)
-              if style.url <> "" then (
+              if sanitized_url <> "" then (
                 Buffer.add_string buf "\027]8;;" ;
-                Buffer.add_string buf style.url ;
+                Buffer.add_string buf sanitized_url ;
                 Buffer.add_string buf "\027\\") ;
-              t.current_url <- style.url
+              t.current_url <- sanitized_url
             end ;
             (* Handle SGR style changes (fg, bg, bold, dim, underline, reverse) *)
             let sgr_differs =

--- a/src/miaou_helpers/helpers.ml
+++ b/src/miaou_helpers/helpers.ml
@@ -30,6 +30,17 @@ let rec skip_osc_until_st s i =
   else if s.[i] = '\027' && i + 1 < len && s.[i + 1] = '\\' then i + 2
   else skip_osc_until_st s (i + 1)
 
+let sanitize_osc_payload s =
+  let buf = Buffer.create (String.length s) in
+  String.iter
+    (fun c ->
+      match c with
+      | '\027' | '\007' | '\x9c' -> ()
+      | c when Char.code c < 0x20 || Char.code c = 0x7F -> ()
+      | c -> Buffer.add_char buf c)
+    s ;
+  Buffer.contents buf
+
 let utf8_decode s i =
   let len = String.length s in
   if i >= len then (0, i + 1)

--- a/src/miaou_helpers/helpers.mli
+++ b/src/miaou_helpers/helpers.mli
@@ -21,6 +21,8 @@ val skip_ansi_until_m : string -> int -> int
 
 val skip_osc_until_st : string -> int -> int
 
+val sanitize_osc_payload : string -> string
+
 val visible_chars_count : string -> int
 
 val visible_byte_index_of_pos : string -> int -> int

--- a/src/miaou_widgets_display/widgets.ml
+++ b/src/miaou_widgets_display/widgets.ml
@@ -29,6 +29,7 @@ let osc8_supported =
     [display] is returned as-is.  Override with MIAOU_TUI_HYPERLINKS=on. *)
 let hyperlink ~url display =
   if Lazy.force osc8_supported then
+    let url = Miaou_helpers.Helpers.sanitize_osc_payload url in
     "\027]8;;" ^ url ^ "\027\\" ^ display ^ "\027]8;;\027\\"
   else display
 

--- a/test/test_matrix_diff.ml
+++ b/test/test_matrix_diff.ml
@@ -38,6 +38,8 @@ let count_substring str sub =
     done ;
     !count
 
+let contains_sub str sub = count_substring str sub > 0
+
 (* Test that diff always starts with cursor positioning *)
 let test_diff_starts_with_moveto () =
   let buf = Buffer.create ~rows:5 ~cols:20 in
@@ -197,6 +199,14 @@ let test_mark_all_dirty_emits_clearing_spaces () =
   in
   check bool "full redraw emits clearing space" true writes_space
 
+let test_writer_sanitizes_osc8_url () =
+  let writer = Writer.create () in
+  let style = {Cell.default_style with url = "https://x/\007\027[2J\x9c\nok"} in
+  let out = Writer.render writer [Diff.SetStyle style; Diff.WriteChar "x"] in
+  check bool "no BEL in writer output" false (String.contains out '\007') ;
+  check bool "no injected clear screen" false (contains_sub out "\027[2J") ;
+  check bool "sanitized URL remains" true (contains_sub out "https://x/[2Jok")
+
 (* Test with real ANSI file if it exists *)
 let test_real_ansi_file () =
   let file = "/tmp/miaou-modal-with-overlay.ansi" in
@@ -244,6 +254,10 @@ let () =
             "mark_all_dirty emits clearing spaces"
             `Quick
             test_mark_all_dirty_emits_clearing_spaces;
+          test_case
+            "writer sanitizes osc8 url"
+            `Quick
+            test_writer_sanitizes_osc8_url;
         ] );
       ( "modal",
         [

--- a/test/test_widgets_helpers.ml
+++ b/test/test_widgets_helpers.ml
@@ -2,6 +2,17 @@ open Alcotest
 module W = Miaou_widgets_display.Widgets
 module Palette_sdl = Miaou_widgets_display.Palette_sdl
 
+let contains_sub haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop i =
+    if nlen = 0 then true
+    else if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else loop (i + 1)
+  in
+  loop 0
+
 let test_ascii_preference () =
   Unix.putenv "MIAOU_TUI_UNICODE_BORDERS" "off" ;
   Unix.putenv "MIAOU_TUI_UNICODE_BORDERS" "on" ;
@@ -145,6 +156,22 @@ let test_osc8_hyperlink () =
   let remaining_visible = H.visible_chars_count remaining in
   check int "remaining visible" 3 remaining_visible
 
+let test_osc8_hyperlink_sanitizes_url () =
+  Unix.putenv "MIAOU_TUI_HYPERLINKS" "on" ;
+  let link = W.hyperlink ~url:"https://x/\007\027[2J\x9c\nok" "click" in
+  check bool "no BEL in hyperlink" false (String.contains link '\007') ;
+  check bool "no injected clear screen" false (contains_sub link "\027[2J") ;
+  check
+    string
+    "shared sanitizer strips controls"
+    "https://x/[2Jok"
+    (Miaou_helpers.Helpers.sanitize_osc_payload "https://x/\007\027[2J\x9c\nok") ;
+  check
+    string
+    "shared sanitizer strips del"
+    "https://x/ok"
+    (Miaou_helpers.Helpers.sanitize_osc_payload "https://x/\x7fok")
+
 let test_osc_sequence_skipping () =
   let module H = Miaou_helpers.Helpers in
   (* is_osc_start detects ESC ] *)
@@ -174,6 +201,10 @@ let () =
           test_case "misc helpers" `Quick test_misc_helpers;
           test_case "wrap+pad helpers" `Quick test_wrap_and_pad;
           test_case "osc8 hyperlink" `Quick test_osc8_hyperlink;
+          test_case
+            "osc8 hyperlink sanitizes url"
+            `Quick
+            test_osc8_hyperlink_sanitizes_url;
           test_case "osc sequence skipping" `Quick test_osc_sequence_skipping;
         ] );
     ]


### PR DESCRIPTION
Closes #145.

## Summary
- add a shared OSC payload sanitizer for terminal-control-sensitive strings
- sanitize Widget.hyperlink URLs before emitting OSC 8
- sanitize Matrix writer URL styles before re-emitting OSC 8
- add widget and Matrix writer regression tests for BEL/ESC/ST injection

## Tests
- dune fmt
- dune build
- dune exec test/test_widgets_helpers.exe
- dune exec test/test_matrix_diff.exe

## Notes
- No CHANGELOG entry in this branch to keep the six independent bugfix PRs conflict-free; a single rollup changelog entry can be added after merge.