### PR TITLE
fix(clipboard): restore osc52 fallback

### DIFF
--- a/src/miaou_interfaces/clipboard.ml
+++ b/src/miaou_interfaces/clipboard.ml
@@ -111,9 +111,9 @@ let copy_primary text =
 
 (** Copy to both clipboard and primary selection. *)
 let copy_both text =
-  let _native_ok = copy_native text in
-  let _primary_ok = copy_primary text in
-  true
+  let native_ok = copy_native text in
+  let primary_ok = copy_primary text in
+  native_ok || primary_ok
 
 let register ~write ?on_copy ?(enabled = true) () =
   let copy_fn =

--- a/test/test_clipboard.ml
+++ b/test/test_clipboard.ml
@@ -71,6 +71,25 @@ let test_clipboard_disabled () =
   clip.copy "test" ;
   check bool "write not called" false !write_called
 
+let test_clipboard_falls_back_to_osc52 () =
+  let old_path = Sys.getenv_opt "PATH" in
+  Fun.protect
+    ~finally:(fun () ->
+      match old_path with
+      | Some path -> Unix.putenv "PATH" path
+      | None -> Unix.putenv "PATH" "")
+    (fun () ->
+      Unix.putenv "PATH" "/nonexistent" ;
+      let written = ref "" in
+      Clipboard.register ~write:(fun s -> written := s) () ;
+      let clip = Clipboard.require () in
+      clip.copy "fallback" ;
+      check
+        string
+        "osc52 fallback is written"
+        (Clipboard.osc52_encode "fallback")
+        !written)
+
 (* Test on_copy callback *)
 let test_clipboard_on_copy () =
   let callback_text = ref "" in
@@ -91,6 +110,7 @@ let () =
         [
           test_case "copy" `Quick test_clipboard_copy;
           test_case "disabled" `Quick test_clipboard_disabled;
+          test_case "osc52 fallback" `Quick test_clipboard_falls_back_to_osc52;
           test_case "on_copy callback" `Quick test_clipboard_on_copy;
         ] );
     ]


### PR DESCRIPTION
Closes #144.

## Summary
- make copy_both report whether any native clipboard path succeeded
- restore OSC 52 fallback when native clipboard tools are unavailable
- add a PATH-isolated fallback regression test

## Tests
- dune fmt
- dune build
- dune exec test/test_clipboard.exe

## Notes
- No CHANGELOG entry in this branch to keep the six independent bugfix PRs conflict-free; a single rollup changelog entry can be added after merge.