### PR TITLE
feat(demos): add clipboard demo

### DIFF
--- a/example/demos/clipboard/README.md
+++ b/example/demos/clipboard/README.md
@@ -1,0 +1,24 @@
+# Clipboard Demo
+
+This demo shows how a Miaou application can copy text through the Clipboard
+capability.
+
+## What It Covers
+
+- Quick-copy actions for fixed sample values
+- A modal textbox workflow for user-entered text
+- Driver capability checks before reporting success
+- Toast feedback for successful, unavailable, and disabled clipboard states
+
+## Controls
+
+- `Space` or `Enter`: open the copy modal
+- `1` to `5`: copy a predefined sample
+- `t`: open this tutorial
+- `Esc`: return to the launcher
+
+## Notes
+
+Drivers register the clipboard capability with
+`Miaou_interfaces.Clipboard.register`. The default terminal drivers try native
+clipboard tools first, then fall back to OSC 52 when native tools are missing.

--- a/example/demos/clipboard/dune
+++ b/example/demos/clipboard/dune
@@ -1,0 +1,15 @@
+(library
+ (name clipboard_demo)
+ (modules page)
+ (preprocess
+  (pps ppx_blob))
+ (preprocessor_deps
+  (file README.md))
+ (libraries demo_shared miaou miaou-core.lib_miaou_internal))
+
+(executable
+ (name main)
+ (public_name miaou.clipboard-demo)
+ (package miaou)
+ (modules main)
+ (libraries clipboard_demo miaou-runner.tui miaou-core.helpers eio_main))

--- a/example/demos/clipboard/main.ml
+++ b/example/demos/clipboard/main.ml
@@ -1,0 +1,17 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* SPDX-License-Identifier: MIT                                              *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+let () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  Miaou_helpers.Fiber_runtime.init ~env ~sw ;
+  Demo_shared.Demo_config.register_mocks () ;
+  Demo_shared.Demo_config.ensure_system_capability () ;
+  let page : Miaou.Core.Registry.page =
+    (module Clipboard_demo.Page : Miaou.Core.Tui_page.PAGE_SIG)
+  in
+  ignore (Miaou_runner_tui.Runner_tui.run page)

--- a/example/demos/clipboard/page.ml
+++ b/example/demos/clipboard/page.ml
@@ -1,0 +1,217 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* SPDX-License-Identifier: MIT                                              *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+module Inner = struct
+  let tutorial_title = "Clipboard"
+
+  let tutorial_markdown = [%blob "README.md"]
+
+  module Clipboard = Miaou_interfaces.Clipboard
+  module Toast = Miaou_widgets_layout.Toast_widget
+  module Textbox = Miaou_widgets_input.Textbox_widget
+
+  let pending_modal_copy : string option ref = ref None
+
+  type state = {
+    toasts : Toast.t;
+    last_copied : string option;
+    copy_count : int;
+    next_page : string option;
+  }
+
+  type msg = unit
+
+  let init () =
+    {
+      toasts = Toast.empty ();
+      last_copied = None;
+      copy_count = 0;
+      next_page = None;
+    }
+
+  let update s (_ : msg) = s
+
+  let go_back s =
+    {s with next_page = Some Demo_shared.Demo_config.launcher_page_name}
+
+  let toast s severity message =
+    {s with toasts = Toast.enqueue s.toasts severity message}
+
+  let copy_text s text =
+    match Clipboard.get () with
+    | None -> toast s Toast.Error "Clipboard not available"
+    | Some clip ->
+        if not (clip.copy_available ()) then
+          toast s Toast.Warn "Clipboard disabled in driver"
+        else (
+          clip.copy text ;
+          {
+            s with
+            toasts =
+              Toast.enqueue
+                s.toasts
+                Toast.Success
+                (Printf.sprintf "Copied: %s" text);
+            last_copied = Some text;
+            copy_count = s.copy_count + 1;
+          })
+
+  let queue_modal_copy text = if text <> "" then pending_modal_copy := Some text
+
+  let open_copy_modal s =
+    let module Copy_modal = struct
+      type state = Textbox.t
+
+      type pstate = state Miaou.Core.Navigation.t
+
+      type msg = unit
+
+      type key_binding = state Miaou.Core.Tui_page.key_binding_desc
+
+      let init () =
+        Miaou.Core.Navigation.make
+          (Textbox.create ~placeholder:(Some "Enter text to copy...") ())
+
+      let view ps ~focus ~size:_ =
+        Textbox.render ps.Miaou.Core.Navigation.s ~focus
+
+      let handle_key ps key_str ~size:_ =
+        Miaou.Core.Navigation.update
+          (fun textbox -> Textbox.handle_key textbox ~key:key_str)
+          ps
+
+      let handle_modal_key ps _ ~size:_ = ps
+
+      let update ps _ = ps
+
+      let move ps _ = ps
+
+      let refresh ps = ps
+
+      let service_select ps _ = ps
+
+      let service_cycle ps _ = ps
+
+      let back ps = ps
+
+      let has_modal _ = false
+
+      let keymap (_ : pstate) = []
+
+      let handled_keys () = []
+
+      let on_key ps key ~size =
+        let key_str = Miaou.Core.Keys.to_string key in
+        (handle_key ps key_str ~size, Miaou_interfaces.Key_event.Bubble)
+
+      let on_modal_key ps key ~size =
+        let key_str = Miaou.Core.Keys.to_string key in
+        (handle_modal_key ps key_str ~size, Miaou_interfaces.Key_event.Bubble)
+
+      let key_hints (_ : pstate) = []
+    end in
+    Miaou.Core.Modal_manager.push
+      (module Copy_modal)
+      ~init:(Copy_modal.init ())
+      ~ui:
+        {
+          title = "Copy text";
+          left = Some 10;
+          max_width = Some (Fixed 60);
+          dim_background = true;
+        }
+      ~commit_on:["Enter"]
+      ~cancel_on:["Esc"]
+      ~on_close:(fun modal_ps -> function
+        | `Commit ->
+            modal_ps.Miaou.Core.Navigation.s |> Textbox.get_text
+            |> queue_modal_copy
+        | `Cancel -> ()) ;
+    s
+
+  let samples =
+    [|
+      "Hello, clipboard!";
+      "git status";
+      "ssh user@example.com";
+      "https://github.com/trilitech/miaou";
+      "Lorem ipsum dolor sit amet";
+    |]
+
+  let view s ~focus:_ ~size =
+    let module W = Miaou_widgets_display.Widgets in
+    let sample_lines =
+      samples |> Array.to_list
+      |> List.mapi (fun i sample ->
+          W.themed_text (Printf.sprintf "%d. %s" (i + 1) sample))
+      |> String.concat "\n"
+    in
+    let last =
+      match s.last_copied with
+      | None -> "none"
+      | Some text ->
+          if String.length text > 34 then String.sub text 0 31 ^ "..." else text
+    in
+    let status =
+      W.themed_muted (Printf.sprintf "Copies: %d | Last: %s" s.copy_count last)
+    in
+    let toasts = Toast.render s.toasts ~cols:size.LTerm_geom.cols in
+    String.concat
+      "\n\n"
+      [
+        W.titleize "Clipboard";
+        W.dim
+          "Space/Enter: modal copy | 1-5: quick copy | t: tutorial | Esc: back";
+        W.themed_text
+          "The demo copies text through the registered Clipboard capability.";
+        sample_lines;
+        status;
+        toasts;
+      ]
+
+  let handle_key s key_str ~size:_ =
+    match Miaou.Core.Keys.of_string key_str with
+    | Some Miaou.Core.Keys.Escape -> go_back s
+    | Some Miaou.Core.Keys.Enter | Some (Miaou.Core.Keys.Char " ") ->
+        open_copy_modal s
+    | Some (Miaou.Core.Keys.Char key) -> (
+        match int_of_string_opt key with
+        | Some n when n >= 1 && n <= Array.length samples ->
+            copy_text s samples.(n - 1)
+        | _ -> s)
+    | _ -> s
+
+  let move s _ = s
+
+  let refresh s =
+    let s = {s with toasts = Toast.tick s.toasts} in
+    match !pending_modal_copy with
+    | None -> s
+    | Some text ->
+        pending_modal_copy := None ;
+        copy_text s text
+
+  let enter s = s
+
+  let service_select s _ = s
+
+  let service_cycle s _ = refresh s
+
+  let handle_modal_key s _ ~size:_ = s
+
+  let next_page s = s.next_page
+
+  let keymap (_ : state) = []
+
+  let handled_keys () = []
+
+  let back s = go_back s
+
+  let has_modal _ = Miaou.Core.Modal_manager.has_active ()
+end
+
+include Demo_shared.Demo_page.MakeSimple (Inner)

--- a/example/gallery/dune
+++ b/example/gallery/dune
@@ -6,6 +6,7 @@
   demo_modals
   ; All demo libraries
   checkbox_demo
+  clipboard_demo
   radio_demo
   switch_demo
   button_demo

--- a/example/gallery/launcher.ml
+++ b/example/gallery/launcher.ml
@@ -493,6 +493,13 @@ let demos =
           "demo_miaou_links"
           (module Miaou_links_demo.Page : Miaou.Core.Tui_page.PAGE_SIG);
     };
+    {
+      title = "Clipboard";
+      open_demo =
+        goto
+          "demo_clipboard"
+          (module Clipboard_demo.Page : Miaou.Core.Tui_page.PAGE_SIG);
+    };
   ]
 
 let demo_at idx = List.nth_opt demos idx
@@ -516,7 +523,7 @@ let demo_tree =
           "Display"
           [2; 4; 8; 9; 10; 26; 28; 29; 30; 31; 33; 34; 35; 36];
       ];
-    demo_group "Core" [6; 7; 37; 45; 46];
+    demo_group "Core" [6; 7; 37; 45; 46; 52];
     demo_group "Styling" [5; 39];
     demo_group "Showcases" [32; 48];
     demo_group "Games" [43; 47; 49; 50; 51];

--- a/test/dune
+++ b/test/dune
@@ -366,6 +366,15 @@
  (libraries alcotest miaou-core.interfaces))
 
 (test
+ (name test_clipboard_demo)
+ (modules test_clipboard_demo)
+ (libraries
+  alcotest
+  clipboard_demo
+  miaou-core.interfaces
+  miaou-core.widgets.layout))
+
+(test
  (name test_canvas)
  (modules test_canvas)
  (libraries alcotest miaou-core.canvas))

--- a/test/test_clipboard_demo.ml
+++ b/test/test_clipboard_demo.ml
@@ -1,0 +1,76 @@
+open Alcotest
+module Demo = Clipboard_demo.Page.Inner
+module Clipboard = Miaou_interfaces.Clipboard
+module Toast = Miaou_widgets_layout.Toast_widget
+
+let register_clipboard ~available ~copied =
+  Clipboard.set
+    {
+      Clipboard.copy = (fun text -> copied := text :: !copied);
+      copy_available = (fun () -> available);
+    }
+
+let toast_messages s =
+  s.Demo.toasts |> Toast.to_list |> List.map (fun t -> t.Toast.message)
+
+let reset_pending () = Demo.pending_modal_copy := None
+
+let test_quick_copy_records_success () =
+  reset_pending () ;
+  let copied = ref [] in
+  register_clipboard ~available:true ~copied ;
+  let s = Demo.copy_text (Demo.init ()) "hello" in
+  check (list string) "copied text" ["hello"] (List.rev !copied) ;
+  check int "copy count" 1 s.copy_count ;
+  check (option string) "last copied" (Some "hello") s.last_copied ;
+  check (list string) "success toast" ["Copied: hello"] (toast_messages s)
+
+let test_disabled_quick_copy_does_not_report_success () =
+  reset_pending () ;
+  let copied = ref [] in
+  register_clipboard ~available:false ~copied ;
+  let s = Demo.copy_text (Demo.init ()) "hello" in
+  check (list string) "nothing copied" [] !copied ;
+  check int "copy count unchanged" 0 s.copy_count ;
+  check (option string) "no last copied" None s.last_copied ;
+  check
+    (list string)
+    "disabled warning"
+    ["Clipboard disabled in driver"]
+    (toast_messages s)
+
+let test_modal_pending_copy_uses_same_disabled_path () =
+  reset_pending () ;
+  let copied = ref [] in
+  register_clipboard ~available:false ~copied ;
+  Demo.queue_modal_copy "modal text" ;
+  let s = Demo.refresh (Demo.init ()) in
+  check (list string) "nothing copied" [] !copied ;
+  check int "copy count unchanged" 0 s.copy_count ;
+  check (option string) "no last copied" None s.last_copied ;
+  check
+    (list string)
+    "disabled warning"
+    ["Clipboard disabled in driver"]
+    (toast_messages s)
+
+let () =
+  run
+    "clipboard_demo"
+    [
+      ( "copy",
+        [
+          test_case
+            "quick copy records success"
+            `Quick
+            test_quick_copy_records_success;
+          test_case
+            "disabled quick copy does not report success"
+            `Quick
+            test_disabled_quick_copy_does_not_report_success;
+          test_case
+            "modal pending copy uses disabled path"
+            `Quick
+            test_modal_pending_copy_uses_same_disabled_path;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add a clean clipboard demo page with quick-copy samples and a modal textbox workflow
- wire the demo into the current gallery launcher
- add regression tests covering success, disabled clipboard quick-copy, and disabled clipboard modal-copy behavior

Supersedes #128 with a fresh branch based on current main and without stale runner/headless history.

## Verification
- dune fmt
- dune exec test/test_clipboard_demo.exe
- dune exec test/test_clipboard.exe
- dune build
- dune runtest