### PR TITLE
fix(build): guard against wrong-opam-switch environments

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+eval "$(opam env --switch . --set-switch)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,28 @@ dune fmt            # Format code (MUST pass before commit)
 
 **Critical:** Every commit must be properly formatted. The pre-commit hook enforces this.
 
+### Building — switch discipline
+
+This project pins its dependencies to a project-local opam switch. Always
+build through `make build` / `make test` / `make fmt` / `make check`, or
+prefix raw `dune` invocations with `opam exec --switch . --` (or the absolute
+project path when running from a nested working directory, e.g. a worktree).
+A bare `dune build` run against an unrelated, wrong-version switch (e.g. one
+built for a different project) will fail to compile with errors that look
+like source bugs but are not — the code is correct under the project-local
+switch. If you see any of the following, suspect the active opam switch
+before touching `src/`:
+
+| Symptom (wrong-switch signature)                          | Likely cause                          |
+|-------------------------------------------------------------|----------------------------------------|
+| `Unbound value Cohttp_eio.Client.make`                       | switch has an incompatible `cohttp-eio` |
+| `Unbound module Eio.Resource` (reported twice)               | switch has a pre-1.0 `eio`             |
+| `~label` mismatch on `run_in_systhread`                      | switch has a mismatched `eio` version   |
+
+These are environment-contamination symptoms, not code defects. Run `make
+check` (or `dune clean && opam exec --switch . -- dune build`) to confirm
+before filing or fixing anything in `src/`.
+
 ## OCaml Coding Standards
 
 ### General Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Build now guarded against wrong-opam-switch environments via Makefile
+  targets and setup docs.
+
 ## [0.5.2] - 2026-05-05
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,41 @@
-.PHONY: all build test fmt clean deps coverage
+.PHONY: all build test fmt check clean deps coverage
+
+# All dune invocations are pinned to this project's local opam switch and
+# project root, regardless of which switch is active in the calling shell
+# or how deep the invoking directory is nested (e.g. under a worktree that
+# lives inside the main checkout and therefore has no _opam of its own).
+# This guards against silent builds/tests against the wrong switch.
+OPAM_SWITCH_DIR := $(shell d="$(CURDIR)"; while [ "$$d" != "/" ]; do \
+	if [ -d "$$d/_opam" ]; then echo "$$d"; break; fi; \
+	d=$$(dirname "$$d"); done)
+ifeq ($(strip $(OPAM_SWITCH_DIR)),)
+$(error No _opam switch found in any ancestor of $(CURDIR); create the project switch first: opam switch create . --deps-only --with-test)
+endif
+DUNE := opam exec --switch $(OPAM_SWITCH_DIR) -- dune
 
 all: build
 
 deps:
-	opam install --deps-only --with-test -y .
+	opam install --deps-only --with-test -y --switch $(OPAM_SWITCH_DIR) .
 
 build:
-	dune build @all
+	$(DUNE) build --root . @all
 
 test:
-	dune runtest
+	$(DUNE) runtest --root .
 
 fmt:
-	dune fmt
+	$(DUNE) fmt --root .
+
+check: build test fmt
 
 clean:
-	dune clean
+	$(DUNE) clean --root .
 
 coverage:
 	rm -rf _coverage
 	mkdir -p _coverage
-	BISECT_ENABLE=YES BISECT_FILE=$(PWD)/_coverage/bisect dune build --instrument-with bisect_ppx @all
+	BISECT_ENABLE=YES BISECT_FILE=$(PWD)/_coverage/bisect $(DUNE) build --root . --instrument-with bisect_ppx @all
 	# Run test executables manually so BISECT_* env vars are honored in sandboxed runs.
 	find _build/default/test -maxdepth 1 -type f -name '*.exe' -print0 | \
 		xargs -0 -n1 env BISECT_ENABLE=YES BISECT_FILE=$(PWD)/_coverage/bisect

--- a/README.md
+++ b/README.md
@@ -108,7 +108,16 @@ Or using the Makefile shortcuts:
 make deps    # opam install --deps-only
 make build   # dune build @all
 make test    # dune runtest
+make fmt     # dune fmt
+make check   # build + test + fmt
 ```
+
+The `make` targets always run `dune` through `opam exec --switch . --`
+against this project's own opam switch, so they build correctly even if a
+different (and incompatible) opam switch happens to be active in your shell.
+If you invoke `dune` directly instead of through `make`, prefix it the same
+way (`opam exec --switch . -- dune build`) — a stray, unrelated switch can
+otherwise produce confusing compile errors that look like source bugs.
 
 Using from another project
 --------------------------

--- a/doc_examples/first_app.ml
+++ b/doc_examples/first_app.ml
@@ -26,8 +26,7 @@ module Counter = Direct_page.Make (Direct_page.With_defaults (struct
 +------------------------+|}
       count
 
-  let view state ~focus:_ ~size:_ =
-    render_count state.count
+  let view state ~focus:_ ~size:_ = render_count state.count
 
   let on_key state key ~size:_ =
     match key with

--- a/doc_examples/responsive_dashboard.ml
+++ b/doc_examples/responsive_dashboard.ml
@@ -16,8 +16,7 @@ let layout_for_width width =
     ~default:Wide
     [{max_width = 59; layout = Narrow}; {max_width = 119; layout = Medium}]
 
-let cell name value =
-  Printf.sprintf "| %-9s %6s " name value
+let cell name value = Printf.sprintf "| %-9s %6s " name value
 
 let render_dashboard ~width =
   match layout_for_width width with

--- a/dune-project
+++ b/dune-project
@@ -113,7 +113,11 @@
  (authors "Nomadic Labs <contact@nomadic-labs.com>")
  (homepage "https://github.com/trilitech/miaou")
  (bug_reports "https://github.com/trilitech/miaou/issues")
- (depends miaou-core miaou-driver-term miaou-driver-matrix)
+ (depends
+  miaou-core
+  miaou-driver-term
+  miaou-driver-matrix
+  (eio (>= 1.0)))
  (depopts miaou-driver-sdl))
 
 (package

--- a/miaou-runner.opam
+++ b/miaou-runner.opam
@@ -12,6 +12,7 @@ depends: [
   "miaou-core"
   "miaou-driver-term"
   "miaou-driver-matrix"
+  "eio" {>= "1.0"}
   "odoc" {with-doc}
 ]
 depopts: ["miaou-driver-sdl"]


### PR DESCRIPTION
## Summary
- Makefile `build`/`test`/`fmt`/`check`/`clean`/`coverage`/`deps` targets pin the project-local opam switch (nearest `_opam` ancestor; clear error when none exists)
- `.envrc` (direnv) + AGENTS.md/README switch-discipline docs with the wrong-switch error-signature table
- `miaou-runner` gains its direct `(eio (>= 1.0))` dependency (+ regenerated `.opam`); two pre-existing `dune fmt` drifts in `doc_examples/` settled
- **Zero `src/` changes** — the audit's "4 compile errors" were wrong-switch environment contamination (octez-setup, eio 0.11), not API drift; the tree is green under its own switch

## Pipeline evidence
- Plan: dual-voice consensus falsified the original brief's premise; re-scoped with human approval (`briefs/restore-build-plan.md`)
- Review: changes-required findings fixed (empty-ancestor guard, coverage/deps pinning) and re-verified
- QA: PASS — `make check` green from clean AND from a polluted `OPAM_SWITCH_PREFIX` shell; >1000 tests pass; `src/` diff empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)