### PR TITLE
fix: crash, UB, and terminal-safety defects (audit G2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build now guarded against wrong-opam-switch environments via Makefile
   targets and setup docs.
 
+### Fixed
+
+- **Grid layout no longer raises on degenerate sizes**: rendering a grid whose padding exceeds the available terminal area (or into a zero-size viewport) used to raise an exception instead of rendering something sensible; the inner content area is now clamped to zero instead of going negative. A negative padding or column-gap value is now also clamped instead of reaching the same crash further down in rendering.
+- **Selection widget accessors are now total**: reading the current selection or its display label after the underlying item list shrinks (a stale cursor position) used to raise instead of reporting "no selection"; a new `value_opt` accessor also lets callers distinguish "no selection" unambiguously. A new `set_items` lets callers replace a widget's items in place (e.g. for a live-filtered list) without losing the cursor position.
+- **File browser caching no longer cross-contaminates instances**: two file-browser widgets browsing different paths, or the same path with different directory-only filters, could previously see each other's cached listing; the cache is now keyed per path/filter combination. Long, multi-byte filenames are also truncated at a safe character boundary instead of potentially producing corrupted text.
+- **Headless test runs stay quiet on stderr by default**: internal driver tracing is now gated behind `MIAOU_DEBUG` instead of always printing.
+- **Modal background dimming now respects the caller's choice**: requesting an undimmed modal background was previously silently ignored and the background was always dimmed.
+- **Terminal restored after a crashing page**: if a page raised an exception while the terminal (Matrix) driver was running, the terminal could be left in raw/alternate-screen/mouse-tracking mode; cleanup now always runs before the error propagates, and the original error/backtrace is preserved.
+- **Signal handling in the terminal driver is safer and more responsive**: the exit-signal handler now only sets a flag and wakes a dedicated fiber (instead of doing terminal I/O directly inside the signal handler), fixing a case where an idle session could be slow to react to Ctrl-C/SIGTERM. A second signal while already shutting down now always attempts a minimal, lock-free terminal restore and force-exits immediately, rather than potentially blocking on the same lock the first signal's normal shutdown path might be stuck on; the conventional exit code for a signal-triggered quit is preserved either way.
+- **Service lifecycle capability no longer risks a crash when only the lower-level interface implementation is registered**: the two representations (this module's and the underlying interface's) previously shared a capability slot via an unsound low-level cast; a lookup now explicitly translates between them, and the accessor functions for starting/stopping/restarting/querying status (previously implemented but not exposed) are now part of the public interface.
+
 ## [0.5.2] - 2026-05-05
 
 ### Fixed

--- a/src/lib_miaou_internal/headless_driver.ml
+++ b/src/lib_miaou_internal/headless_driver.ml
@@ -23,6 +23,20 @@ module Theme_loader = Miaou_style.Theme_loader
 module Keys = Miaou_core.Keys
 open LTerm_geom
 
+(* Debug tracing, gated behind MIAOU_DEBUG (same pattern as
+   Modal_manager.dprintf) so headless test runs stay silent on stderr by
+   default instead of unconditionally emitting "[driver][debug]" lines on
+   every key/refresh. *)
+let debug_enabled =
+  lazy
+    (match Sys.getenv_opt "MIAOU_DEBUG" with
+    | Some ("1" | "true" | "TRUE" | "yes" | "YES") -> true
+    | _ -> false)
+
+let dprintf fmt =
+  if Lazy.force debug_enabled then Printf.eprintf fmt
+  else Printf.ifprintf Stdlib.stdout fmt
+
 (** Convert a string key name to a [Keys.t], falling back to [Char s]. *)
 let key_of_string s =
   match Keys.of_string s with Some k -> k | None -> Keys.Char s
@@ -154,21 +168,16 @@ let run (initial_page : (module Tui_page.PAGE_SIG)) :
         render_page_with (module P) ps ;
         match Key_queue.take () with
         | None -> (
-            (try
-               Printf.eprintf
-                 "[driver][debug] No key in queue, refreshing page\n%!"
-             with _ -> ()) ;
+            dprintf "[driver][debug] No key in queue, refreshing page\n%!" ;
             let ps' = P.refresh ps |> apply_pending_modal_nav in
             match Navigation.pending ps' with
             | Some nav -> nav_to_outcome nav
             | None -> loop (iteration + 1) ps')
         | Some k -> (
-            (try
-               Printf.eprintf
-                 "[driver][debug] Key event: '%s' modal_active=%b\n%!"
-                 k
-                 (Miaou_core.Modal_manager.has_active ())
-             with _ -> ()) ;
+            dprintf
+              "[driver][debug] Key event: '%s' modal_active=%b\n%!"
+              k
+              (Miaou_core.Modal_manager.has_active ()) ;
             let forced_switch =
               String.length k > 11
               && String.sub k 0 11 = "__SWITCH__:"
@@ -180,11 +189,9 @@ let run (initial_page : (module Tui_page.PAGE_SIG)) :
             else
               let ps' =
                 if Miaou_core.Modal_manager.has_active () then (
-                  (try
-                     Printf.eprintf
-                       "[driver][debug] Modal manager handling key: '%s'\n%!"
-                       k
-                   with _ -> ()) ;
+                  dprintf
+                    "[driver][debug] Modal manager handling key: '%s'\n%!"
+                    k ;
                   Miaou_core.Modal_manager.handle_key k ;
                   ps)
                 else

--- a/src/miaou_core/modal_manager.ml
+++ b/src/miaou_core/modal_manager.ml
@@ -82,6 +82,19 @@ let push (type s) (module P : Tui_page.PAGE_SIG with type state = s)
     (fun i (Frame r) ->
       dprintf "[DEBUG]   [%d] existing: '%s'\n%!" i r.ui.title)
     !stack ;
+  (* Same-title replacement: any existing frame with this title is evicted
+     without its [on_close] running (see mli for why this is intentional,
+     existing behavior rather than a bug to fix here). Log it when it
+     actually happens so the silent-eviction semantics are at least
+     observable while debugging. *)
+  (match List.find_opt (fun (Frame r) -> r.ui.title = ui.title) !stack with
+  | Some _ ->
+      dprintf
+        "[DEBUG] Modal_manager.push: evicting existing frame with same title \
+         '%s' (on_close NOT invoked)\n\
+         %!"
+        ui.title
+  | None -> ()) ;
   stack := List.filter (fun (Frame r) -> r.ui.title <> ui.title) !stack ;
   let fr =
     Frame {p = (module P); st = init; ui; commit_on; cancel_on; on_close}

--- a/src/miaou_core/modal_manager.mli
+++ b/src/miaou_core/modal_manager.mli
@@ -45,6 +45,22 @@ val clear : unit -> unit
     presses Enter, use [push] with [commit_on:[]] instead of [push_default].
     Otherwise, the parent modal will close immediately after the child modal
     opens, because the key check happens {i after} your [handle_key] is called.
+
+    {b Same-title replacement semantics}: if a frame with the same [ui.title]
+    is already on the stack, it is silently evicted (removed) before the new
+    frame is pushed — {i without} invoking its [on_close] callback. This is
+    existing, intentional behavior relied on by real call sites (e.g.
+    re-showing a modal with a default title, or a caller that replaces a
+    narrow-terminal/file-browser modal by title); changing it to fire
+    [on_close] on eviction, or to key frames by a unique id instead of title,
+    both break those flows and are tracked as a deferred design change (see
+    the crash-ub-fixes plan's structural-debt backlog) rather than fixed
+    here. If you rely on cleanup logic in [on_close], do not assume it runs
+    when your modal is replaced by a same-titled [push] — only when it is
+    closed via {!close_top}, a [commit_on]/[cancel_on] key, or the key
+    handler's cancel/commit path. A debug line is emitted (gated behind
+    [MIAOU_TUI_DEBUG_MODAL]) whenever a push evicts an existing same-titled
+    frame this way, to make the behavior observable when debugging.
 *)
 val push :
   (module Tui_page.PAGE_SIG with type state = 's) ->

--- a/src/miaou_core/service_lifecycle.ml
+++ b/src/miaou_core/service_lifecycle.ml
@@ -35,31 +35,76 @@ type t = {
 }
 
 module Capability = Miaou_interfaces.Capability
+module Iface = Miaou_interfaces.Service_lifecycle
 
-(* Use the same capability key instance as the interface so registration by the
-   Systemd-backed implementation (which registers the interface key) is visible
-   here. Coerce the interface key to this module's type with Obj.magic. *)
-let key : t Capability.key =
-  Obj.magic
-    Miaou_interfaces.Service_lifecycle.key
-  [@allow_forbidden "coerce interface key to local type"]
+(* This module's [t] and the interface's [Iface.t] are NOT the same runtime
+   representation: [Iface.status] is a polymorphic variant
+   ([`Active | `Inactive | `Failed of string]) versus this module's regular
+   variant ([Running | Stopped | Failed of string]), and
+   [Iface.remove_instance_files] takes no [~role] while this module's does.
+   The previous implementation shared one capability key across both types
+   via [Obj.magic] and, on the interface fallback path, additionally
+   [Obj.magic]-cast an [Iface.t] value directly into this module's [t] —
+   an unsound coercion between records of differently-shaped closures:
+   calling the miscast [remove_instance_files] or [get_status] with this
+   module's arity/return-type expectations reads/calls through the wrong
+   closure layout (arity mismatch — segfault-class, not merely a type
+   error caught by the compiler).
+
+   Fixed with an explicit, signature-preserving adapter: this module keeps
+   its own independent capability key (so its public [key]/[set]/[get]/
+   [require] signatures are unchanged for existing callers), and
+   [of_interface] below builds a proper [t] value from an [Iface.t] by
+   translating each field explicitly instead of reinterpreting bytes. *)
+let key : t Capability.key = Capability.create ~name:"service_lifecycle"
 
 let set v = Capability.set key v
+
+let status_of_interface : Iface.service_status -> status = function
+  | `Active -> Running
+  | `Inactive -> Stopped
+  | `Failed msg -> Failed msg
+
+(* Adapt an interface-level implementation into this module's [t] shape.
+   [remove_instance_files] has no [~role] on the interface side; the role
+   passed here is accepted (to match this module's signature) and simply
+   not forwarded, matching the interface's role-agnostic semantics. *)
+let of_interface (iv : Iface.t) : t =
+  {
+    start = (fun ~role ~service -> Iface.start iv ~role ~service);
+    stop = (fun ~role ~service -> Iface.stop iv ~role ~service);
+    restart = (fun ~role ~service -> Iface.restart iv ~role ~service);
+    get_status =
+      (fun ~role ~service ->
+        match Iface.get_status iv ~role ~service with
+        | Ok s -> Ok (status_of_interface s)
+        | Error e -> Error e);
+    install_unit =
+      (fun ~role ~app_bin_dir ~user ->
+        Iface.install_unit iv ~role ~app_bin_dir ~user);
+    write_dropin_node =
+      (fun ~inst ~data_dir ~app_bin_dir ->
+        Iface.write_dropin_node iv ~inst ~data_dir ~app_bin_dir);
+    enable_start = (fun ~role ~inst -> Iface.enable_start iv ~role ~inst);
+    enable = (fun ~role ~inst -> Iface.enable iv ~role ~inst);
+    disable = (fun ~role ~inst -> Iface.disable iv ~role ~inst);
+    remove_instance_files =
+      (fun ~role:_ ~inst ~remove_data ->
+        Iface.remove_instance_files iv ~inst ~remove_data);
+  }
 
 let get () =
   match Capability.get key with
   | Some v -> Some v
   | None -> (
-      (* If another module registered the interface-level capability under
-         the interface's key, consult it and coerce to our type. This covers
-         registration ordering races where the interface registration may
-         be visible via the interface module but not via this module's
-         local key instance. *)
-      match Miaou_interfaces.Service_lifecycle.get () with
-      | Some v ->
-          Some
-            (Obj.magic
-               v [@allow_forbidden "coerce interface type to local type"])
+      (* If another module registered only the interface-level capability
+         (e.g. a Systemd-backed implementation registering via
+         [Iface.register]), adapt it into this module's [t] rather than
+         reinterpreting its bytes. This covers registration-ordering races
+         where the interface registration may be visible via the interface
+         module but not via this module's local key instance. *)
+      match Iface.get () with
+      | Some iv -> Some (of_interface iv)
       | None -> None)
 
 let require () =

--- a/src/miaou_core/service_lifecycle.mli
+++ b/src/miaou_core/service_lifecycle.mli
@@ -21,10 +21,23 @@
 
     Example
     {[
-      let start ~service = (* spawn systemd unit or run command *) in
-      let stop ~service = (* stop unit *) in
-      let get_status ~service = Ok Miaou_core.Service_lifecycle.Running in
-      Miaou_core.Service_lifecycle.set { start; stop; restart=(fun ~service -> Ok ()); get_status }
+      let unavailable = Error "not implemented" in
+      Miaou_core.Service_lifecycle.set
+        {
+          start = (fun ~role:_ ~service:_ -> (* spawn systemd unit or run command *) Ok ());
+          stop = (fun ~role:_ ~service:_ -> Ok ());
+          restart = (fun ~role:_ ~service:_ -> Ok ());
+          get_status =
+            (fun ~role:_ ~service:_ -> Ok Miaou_core.Service_lifecycle.Running);
+          install_unit = (fun ~role:_ ~app_bin_dir:_ ~user:_ -> unavailable);
+          write_dropin_node =
+            (fun ~inst:_ ~data_dir:_ ~app_bin_dir:_ -> unavailable);
+          enable_start = (fun ~role:_ ~inst:_ -> unavailable);
+          enable = (fun ~role:_ ~inst:_ -> unavailable);
+          disable = (fun ~role:_ ~inst:_ -> unavailable);
+          remove_instance_files =
+            (fun ~role:_ ~inst:_ ~remove_data:_ -> unavailable);
+        }
     ]}
 *)
 
@@ -59,6 +72,20 @@ val set : t -> unit
 val get : unit -> t option
 
 val require : unit -> t
+
+(* [start]/[stop]/[restart]/[get_status] were implemented in the .ml but
+   never declared here, so this abstract-[t] public interface could not
+   actually be used for the capability's namesake operations (start/stop/
+   status) — only the unit-install/enable/disable/remove_instance_files
+   side. Exposed here (crash-ub-fixes slice S9): purely additive, no
+   existing declaration changed. *)
+val start : t -> role:string -> service:string -> (unit, string) result
+
+val stop : t -> role:string -> service:string -> (unit, string) result
+
+val restart : t -> role:string -> service:string -> (unit, string) result
+
+val get_status : t -> role:string -> service:string -> (status, string) result
 
 val install_unit :
   t ->

--- a/src/miaou_driver_common/terminal_raw.ml
+++ b/src/miaou_driver_common/terminal_raw.ml
@@ -22,6 +22,14 @@ type t = {
      sequences. The TUI then renders inline at the cursor position
      and its final frame stays in the terminal scrollback. *)
   mutable use_alt_screen : bool;
+  (* Self-pipe used by {!install_signals'}'s async-signal-safe exit-signal
+     handler to wake a fiber blocked in a blocking read/await on another fd
+     (e.g. the Matrix driver's input reader, parked in
+     [Eio_unix.await_readable]). The handler only sets [exit_flag] and
+     writes one byte here — no mutex, no cleanup call, no [exit] — leaving
+     graceful shutdown to whichever fiber observes the flag/pipe from
+     ordinary (non-signal) context. Created lazily on first use. *)
+  mutable signal_pipe : (Unix.file_descr * Unix.file_descr) option;
 }
 
 let write_all_fd fd bytes =
@@ -62,9 +70,25 @@ let setup () =
     write_mutex = Mutex.create ();
     exit_screen_dump = None;
     use_alt_screen = true;
+    signal_pipe = None;
   }
 
 let set_exit_screen_dump t dump = t.exit_screen_dump <- Some dump
+
+(* Lazily create (once) the self-pipe used to wake a fiber blocked on
+   another fd when an exit signal arrives. Returns the existing pipe if
+   already created. *)
+let ensure_signal_pipe t =
+  match t.signal_pipe with
+  | Some p -> p
+  | None ->
+      let read_fd, write_fd = Unix.pipe ~cloexec:true () in
+      Unix.set_nonblock write_fd ;
+      let p = (read_fd, write_fd) in
+      t.signal_pipe <- Some p ;
+      p
+
+let signal_read_fd t = fst (ensure_signal_pipe t)
 
 let set_alt_screen t enabled = t.use_alt_screen <- enabled
 
@@ -295,7 +319,29 @@ let size t =
 
 let invalidate_size_cache t = t.cached_size <- None
 
+(* [install_signals'] uses an async-signal-safe handler: the first exit
+   signal only sets [exit_flag] and writes one wake byte to the self-pipe
+   (see [signal_read_fd]) — no mutex, no cleanup call, no [exit]. This lets
+   a fiber blocked on another fd (e.g. a reader parked in
+   [Eio_unix.await_readable]) wake up promptly by also watching the
+   self-pipe's read end, then run its own graceful shutdown (stop
+   readers/render loop, clean up the terminal, exit 130) from ordinary
+   fiber context instead of from inside the signal handler.
+
+   A second signal received while [exit_flag] is already set is treated as
+   "already shutting down, or stuck" and force-exits unconditionally: it
+   does NOT call [on_exit] (which, via [Terminal_raw.cleanup], acquires
+   [t.write_mutex] — exactly the kind of blocking operation that may have
+   wedged the graceful path this is meant to escape from calling it here
+   would let the escape hatch itself deadlock on the same lock). Instead it
+   writes a best-effort, mutex-free terminal-reset sequence directly to the
+   tty fd (a single unlocked [Unix.write], errors swallowed) and then calls
+   [Unix._exit] rather than [Stdlib.exit], since [Stdlib.exit] runs
+   [at_exit] callbacks — including the very [Terminal_raw.cleanup] callback
+   that takes the mutex — which would reintroduce the same deadlock risk on
+   the way out. *)
 let install_signals' t ~on_resize ~on_exit ?(handle_sigint = true) () =
+  ignore on_exit ;
   let exit_flag = Atomic.make false in
   let sigwinch = 28 in
   (* Install resize handler *)
@@ -308,19 +354,38 @@ let install_signals' t ~on_resize ~on_exit ?(handle_sigint = true) () =
             Atomic.set t.resize_pending true ;
             on_resize ()))
    with _ -> ()) ;
-  (* Install exit handlers *)
+  let _read_fd, write_fd = ensure_signal_pipe t in
+  let write_wake_byte () =
+    try ignore (Unix.write write_fd (Bytes.make 1 '\000') 0 1) with _ -> ()
+  in
+  (* Mutex-free, best-effort emergency terminal restore for the second-
+     signal escape hatch: exit alt-screen, disable mouse tracking, show
+     cursor, reset style. Deliberately a single unlocked [Unix.write] (no
+     [with_write_lock], no retry loop) — this path exists specifically for
+     when the normal, mutex-guarded cleanup may be stuck. *)
+  let emergency_restore () =
+    let seq =
+      "\027[?1049l"
+      ^ "\027[?1006l\027[?1015l\027[?1005l\027[?1003l\027[?1002l\027[?1000l"
+      ^ "\027[?25h\027[0m"
+    in
+    try
+      ignore
+        (Unix.write t.tty_out_fd (Bytes.of_string seq) 0 (String.length seq))
+    with _ -> ()
+  in
   let set_exit_handler sigv =
     try
       Sys.set_signal
         sigv
         (Sys.Signal_handle
            (fun _ ->
-             (* Run cleanup synchronously in signal handler *)
-             (try on_exit () with _ -> ()) ;
-             (* Set flag so main loop can exit gracefully *)
-             Atomic.set exit_flag true ;
-             (* Exit immediately *)
-             exit 130))
+             if Atomic.get exit_flag then (
+               emergency_restore () ;
+               Unix._exit 130)
+             else (
+               Atomic.set exit_flag true ;
+               write_wake_byte ())))
     with _ -> ()
   in
   if handle_sigint then set_exit_handler Sys.sigint
@@ -330,8 +395,58 @@ let install_signals' t ~on_resize ~on_exit ?(handle_sigint = true) () =
   (try set_exit_handler Sys.sigquit with _ -> ()) ;
   exit_flag
 
+(* Classic (non-self-pipe) signal installation, kept for consumers whose
+   exit_flag consumers only ever poll it with a bounded sleep (never block
+   indefinitely on another fd) — e.g. the lambda-term driver, via
+   term_terminal_setup. Cleanup runs synchronously in the handler followed
+   by an immediate [exit 130], exactly as before this plan's
+   Matrix-driver-focused self-pipe rework; deliberately not unified with
+   {!install_signals'} to avoid changing an already-working, differently-
+   shaped consumer without an interactive terminal available to verify
+   signal behavior end-to-end.
+
+   This does NOT make the in-handler cleanup safe — it is still running
+   arbitrary terminal I/O (including acquiring [t.write_mutex] via
+   [Terminal_raw.cleanup]) from inside a signal handler. If another domain
+   holds [write_mutex] when the signal arrives, [on_exit ()] here blocks
+   until that domain releases it, which can deadlock the handler (and thus
+   the process, since nothing else runs [exit 130] on this path). The
+   lambda-term driver's bounded-sleep polling of [exit_flag] only bounds
+   how promptly a *different*, non-blocked consumer notices the flag; it
+   does nothing to prevent this handler itself from wedging. This known
+   risk is deliberately left as-is here and deferred to the same
+   structural-debt package as the self-pipe rework for this path — fixing
+   it properly needs the mutex-free/self-pipe treatment {!install_signals'}
+   already has, applied to this path's consumers, which is out of scope for
+   this conservative, non-unifying change. *)
 let install_signals t ~on_resize ~on_exit =
-  install_signals' t ~on_resize ~on_exit ~handle_sigint:true ()
+  let exit_flag = Atomic.make false in
+  let sigwinch = 28 in
+  (try
+     Sys.set_signal
+       sigwinch
+       (Sys.Signal_handle
+          (fun _ ->
+            invalidate_size_cache t ;
+            Atomic.set t.resize_pending true ;
+            on_resize ()))
+   with _ -> ()) ;
+  let set_exit_handler sigv =
+    try
+      Sys.set_signal
+        sigv
+        (Sys.Signal_handle
+           (fun _ ->
+             (try on_exit () with _ -> ()) ;
+             Atomic.set exit_flag true ;
+             exit 130))
+    with _ -> ()
+  in
+  set_exit_handler Sys.sigint ;
+  set_exit_handler Sys.sigterm ;
+  (try set_exit_handler Sys.sighup with _ -> ()) ;
+  (try set_exit_handler Sys.sigquit with _ -> ()) ;
+  exit_flag
 
 let resize_pending t = Atomic.get t.resize_pending
 

--- a/src/miaou_driver_common/terminal_raw.mli
+++ b/src/miaou_driver_common/terminal_raw.mli
@@ -86,6 +86,14 @@ val install_signals' :
   unit ->
   bool Atomic.t
 
+(** The read end of the self-pipe woken by {!install_signals'}'s
+    async-signal-safe exit-signal handler (one byte is written on the first
+    exit signal). A fiber otherwise blocked awaiting readability on a
+    different fd (e.g. terminal input) should also await this fd so it
+    wakes up promptly when an exit signal arrives, instead of relying on
+    unrelated activity on its own fd. Created lazily on first call. *)
+val signal_read_fd : t -> Unix.file_descr
+
 (** Check if a resize signal was received since last clear. *)
 val resize_pending : t -> bool
 

--- a/src/miaou_driver_matrix/matrix_driver.ml
+++ b/src/miaou_driver_matrix/matrix_driver.ml
@@ -16,6 +16,26 @@ let available = true
 
 module Fibers = Miaou_helpers.Fiber_runtime
 
+(* Run [f], always invoking [cleanup] afterwards — whether [f] returns
+   normally or raises. Unlike [Fun.protect ~finally:cleanup f], a failure
+   inside [cleanup] itself is swallowed rather than wrapped in
+   [Finally_raised], and an exception from [f] is re-raised with its
+   original backtrace preserved via [Printexc.raise_with_backtrace] instead
+   of being masked. This is what lets a crashing page still leave the
+   terminal in a restored, usable state (see slice S6 of the
+   crash-ub-fixes plan): the caller's [cleanup] is expected to internally
+   guard each of its own steps (see [run] below) so one failing step (e.g.
+   a write to an already-closed fd) doesn't skip the rest. *)
+let run_with_cleanup ~cleanup f =
+  match f () with
+  | result ->
+      (try cleanup () with _ -> ()) ;
+      result
+  | exception exn ->
+      let bt = Printexc.get_raw_backtrace () in
+      (try cleanup () with _ -> ()) ;
+      Printexc.raise_with_backtrace exn bt
+
 let run ?(config = None) (initial_page : (module Tui_page.PAGE_SIG)) :
     [`Quit | `Back | `SwitchTo of string] =
   Fibers.with_page_switch (fun env _page_sw ->
@@ -108,17 +128,40 @@ let run ?(config = None) (initial_page : (module Tui_page.PAGE_SIG)) :
         {config; buffer; parser; render_loop; io}
       in
 
-      (* Run the shared main loop *)
-      let result = Matrix_main_loop.run ctx ~env initial_page in
-
-      (* Cleanup *)
-      Matrix_input.stop input ;
-      Matrix_render_loop.shutdown render_loop ;
-      Matrix_terminal.write terminal Matrix_ansi_writer.cursor_show ;
-      Matrix_terminal.write terminal "\027[0m" ;
-      (* Save screen content for debugging - will be printed after exit *)
-      let screen_dump = Matrix_buffer.dump_to_string buffer in
-      Matrix_terminal.set_exit_screen_dump terminal screen_dump ;
-      Matrix_terminal.cleanup terminal ;
-
-      result)
+      (* Cleanup steps, each individually guarded so a failure in one step
+         (e.g. a write to a closed fd) does not prevent the rest of the
+         terminal restoration from running. [Matrix_terminal.cleanup] is
+         idempotent (guarded by [cleanup_done]), so it is safe to call it
+         here even though [at_exit] above will also call it: on the normal
+         (non-exceptional) path this call does the real work and the later
+         [at_exit] invocation is a no-op; on the exceptional path (a page or
+         the loop raising) it is the only place the terminal gets restored
+         before the process unwinds to [at_exit] — otherwise a crashing page
+         would leave the user's shell stuck in raw/alt-screen/mouse-tracking
+         mode. See [run_with_cleanup] above for why this uses a manual
+         try/with instead of [Fun.protect]. *)
+      let safe_step f = try f () with _ -> () in
+      let cleanup () =
+        safe_step (fun () -> Matrix_input.stop input) ;
+        safe_step (fun () -> Matrix_render_loop.shutdown render_loop) ;
+        safe_step (fun () ->
+            Matrix_terminal.write terminal Matrix_ansi_writer.cursor_show) ;
+        safe_step (fun () -> Matrix_terminal.write terminal "\027[0m") ;
+        safe_step (fun () ->
+            (* Save screen content for debugging - will be printed after exit *)
+            let screen_dump = Matrix_buffer.dump_to_string buffer in
+            Matrix_terminal.set_exit_screen_dump terminal screen_dump) ;
+        safe_step (fun () -> Matrix_terminal.cleanup terminal)
+      in
+      let result =
+        run_with_cleanup ~cleanup (fun () ->
+            Matrix_main_loop.run ctx ~env initial_page)
+      in
+      (* Preserve the conventional 130 exit code for a signal-triggered
+         quit. The terminal is already fully restored by [cleanup] above at
+         this point, so it is safe to exit immediately; this also sidesteps
+         waiting on any fiber the signal's blocking wait left behind (e.g.
+         the reader fiber, if it never separately woke up), matching the
+         existing hard-exit pattern used elsewhere in the driver stack
+         rather than requiring full graceful fiber cancellation. *)
+      if Matrix_input.signaled input then exit 130 else result)

--- a/src/miaou_driver_matrix/matrix_input.ml
+++ b/src/miaou_driver_matrix/matrix_input.ml
@@ -58,6 +58,12 @@ type t = {
   queue : Event_queue.t;
   shutdown : bool Atomic.t;
   mutable last_refresh_time : float;
+  (* Read end of the self-pipe woken by Terminal_raw's async-signal-safe
+     exit-signal handler. Watched by a dedicated fiber (see [start]) so an
+     exit signal wakes the driver promptly even if the reader fiber's
+     [Eio_unix.await_readable] on the terminal fd would otherwise not be
+     interrupted by the signal (observed with some Eio backends). *)
+  signal_fd : Unix.file_descr;
 }
 
 (* Refresh interval in seconds — controls how often a synthetic Refresh
@@ -135,6 +141,7 @@ let create ?(handle_sigint = true) terminal =
       ~handle_sigint
       ()
   in
+  let signal_fd = Matrix_terminal.signal_read_fd terminal in
   {
     terminal;
     parser = Parser.create fd;
@@ -142,16 +149,47 @@ let create ?(handle_sigint = true) terminal =
     queue = Event_queue.create ();
     shutdown = Atomic.make false;
     last_refresh_time = 0.0;
+    signal_fd;
   }
 
-(** Start the background reader fiber.  Must be called after terminal
-    raw-mode setup, from inside an Eio switch. *)
+(** Pipe-watcher fiber: blocks on the self-pipe's read end so an exit
+    signal is observed immediately (even while the reader fiber is
+    separately blocked awaiting terminal input), then pushes a [Quit]
+    event so the main tick loop notices it on its next tick — independent
+    of whether the reader fiber ever wakes up.
+
+    [t.shutdown] is only set when the wake is actually attributable to an
+    exit signal ([exit_flag] observed true) or to the enclosing switch
+    being cancelled — not on every wake. A bare EINTR, or [await_readable]
+    returning with [exit_flag] still false (e.g. some other unrelated
+    readability edge), is not evidence that a shutdown was requested, so
+    the loop keeps watching instead of stopping the reader on a false
+    alarm. *)
+let rec pipe_watcher_loop (t : t) env =
+  match Eio_unix.await_readable t.signal_fd with
+  | () ->
+      if Atomic.get t.exit_flag then (
+        Event_queue.push t.queue Matrix_io.Quit ;
+        Atomic.set t.shutdown true)
+      else pipe_watcher_loop t env
+  | exception Eio.Cancel.Cancelled _ -> Atomic.set t.shutdown true
+  | exception Unix.Unix_error (Unix.EINTR, _, _) -> pipe_watcher_loop t env
+
+(** Start the background reader fiber and the signal pipe-watcher fiber.
+    Must be called after terminal raw-mode setup, from inside an Eio
+    switch. *)
 let start t =
   let open Miaou_helpers.Fiber_runtime in
-  spawn (fun env -> reader_loop t env)
+  spawn (fun env -> reader_loop t env) ;
+  spawn (fun env -> pipe_watcher_loop t env)
 
 (** Signal the reader fiber to stop. *)
 let stop t = Atomic.set t.shutdown true
+
+(** Whether an exit signal (SIGINT/SIGTERM/...) was received. Used by the
+    caller to preserve the conventional 130 exit code on the graceful
+    (post-cleanup) shutdown path. *)
+let signaled t = Atomic.get t.exit_flag
 
 (** Drain all pending events (oldest first). *)
 let drain t = Event_queue.drain t.queue

--- a/src/miaou_driver_matrix/matrix_input.mli
+++ b/src/miaou_driver_matrix/matrix_input.mli
@@ -24,13 +24,19 @@ type t
       allowing the app to receive it as a key event. Default: true *)
 val create : ?handle_sigint:bool -> Matrix_terminal.t -> t
 
-(** Start the background reader fiber.  Must be called after entering
-    terminal raw mode, from inside an Eio switch (uses
-    {!Miaou_helpers.Fiber_runtime.spawn}). *)
+(** Start the background reader fiber and the signal pipe-watcher fiber.
+    Must be called after entering terminal raw mode, from inside an Eio
+    switch (uses {!Miaou_helpers.Fiber_runtime.spawn}). *)
 val start : t -> unit
 
 (** Signal the reader fiber to stop. *)
 val stop : t -> unit
+
+(** Whether an exit signal (SIGINT/SIGTERM/SIGHUP/SIGQUIT) was received.
+    Callers use this to preserve the conventional 130 exit code on the
+    graceful post-cleanup shutdown path, since the terminal-cleanup handler
+    itself no longer calls [exit] directly on the first signal. *)
+val signaled : t -> bool
 
 (** Drain all pending events from the queue (oldest first).
     Returns the empty list when nothing is buffered. *)

--- a/src/miaou_driver_matrix/matrix_terminal.ml
+++ b/src/miaou_driver_matrix/matrix_terminal.ml
@@ -33,6 +33,8 @@ let invalidate_size_cache = Raw.invalidate_size_cache
 
 let resize_pending = Raw.resize_pending
 
+let signal_read_fd = Raw.signal_read_fd
+
 let clear_resize_pending = Raw.clear_resize_pending
 
 let install_signals t cleanup_fn =

--- a/src/miaou_driver_matrix/matrix_terminal.mli
+++ b/src/miaou_driver_matrix/matrix_terminal.mli
@@ -56,6 +56,12 @@ val install_signals : t -> (unit -> unit) -> bool Atomic.t
 val install_signals' :
   t -> (unit -> unit) -> ?handle_sigint:bool -> unit -> bool Atomic.t
 
+(** The read end of the self-pipe woken by {!install_signals'}'s
+    async-signal-safe exit-signal handler. A fiber blocked awaiting
+    readability on another fd should also await this one so it wakes up
+    promptly on an exit signal instead of only on unrelated fd activity. *)
+val signal_read_fd : t -> Unix.file_descr
+
 (** Check if resize is pending (set by SIGWINCH). *)
 val resize_pending : t -> bool
 

--- a/src/miaou_driver_term/lambda_term_driver.ml
+++ b/src/miaou_driver_term/lambda_term_driver.ml
@@ -111,12 +111,14 @@ let render_diff ~rows last_lines next_lines =
 
 module LT = LTerm
 
-type t = private T
+(* [type t = private T] plus a [(Obj.magic 0 : t)] "dummy private type"
+   stub used to live here as a placeholder driver-interface shape. It was
+   never constructed by any real value and had no legitimate producer, only
+   this fabricated one — a textbook Obj.magic misuse with no safety
+   justification (crash-ub-fixes slice S8). Removed; nothing referenced
+   [t] or [size] outside this module. *)
 
 let available = true
-
-let size () =
-  (Obj.magic 0 : t) [@allow_forbidden "dummy private type for driver interface"]
 
 module Events = Term_events
 

--- a/src/miaou_internals/modal_renderer.ml
+++ b/src/miaou_internals/modal_renderer.ml
@@ -145,7 +145,6 @@ let render_overlay ~(cols : int option) ~base ?rows () =
                 let content =
                   wrap_content_to_width raw_content geom.content_width
                 in
-                let dim_background = dim_background || true in
                 (* Derive an adaptive max_height from the current base output lines.
                    Keep a higher floor so content like Select lists isn't clipped by header lines. *)
                 let max_height = geom.max_height in

--- a/src/miaou_runner/tui_driver_common.ml
+++ b/src/miaou_runner/tui_driver_common.ml
@@ -16,10 +16,12 @@ type outcome = [`Quit | `Back | `SwitchTo of string]
 
 type backend = {available : bool; run : (module PAGE_SIG) -> outcome}
 
-type t = private T
-
-let size () =
-  (Obj.magic 0 : t) [@allow_forbidden "dummy private type for driver interface"]
+(* [type t = private T] plus a [(Obj.magic 0 : t)] "dummy private type"
+   stub used to live here as a placeholder driver-interface shape. It was
+   never constructed by any real value and had no legitimate producer,
+   only this fabricated one — a textbook Obj.magic misuse with no safety
+   justification (crash-ub-fixes slice S8). Removed; nothing referenced
+   [t] or [size] outside this module. *)
 
 let poll_event () = "" (* placeholder synchronous event *)
 
@@ -100,12 +102,17 @@ let run ~term_backend ~sdl_backend ~matrix_backend ~web_backend
         | None -> `Quit)
   in
   let _result = loop initial_page in
-  (* Shutdown fibers and exit to avoid Eio.Switch.run waiting for them *)
-  Miaou_helpers.Fiber_runtime.shutdown () ;
+  (* Shutdown fibers and exit to avoid Eio.Switch.run waiting for them.
+     Kept deliberately (crash-ub-fixes plan, D11): [Fiber_runtime.shutdown]
+     does not cancel any outstanding fiber, so removing this hard [exit 0]
+     would make the process hang waiting for [Eio.Switch.run] to close over
+     fibers that are never asked to stop (e.g. a reader fiber blocked in a
+     blocking await with no more input). Replacing it with a graceful
+     return requires a real fiber-cancellation design and is deferred to
+     the structural-debt backlog, not fixed piecemeal here. *)
   exit 0
 
 let () =
-  ignore size ;
   ignore poll_event ;
   ignore draw_text ;
   ignore clear ;

--- a/src/miaou_widgets_input/select_widget.ml
+++ b/src/miaou_widgets_input/select_widget.ml
@@ -61,7 +61,11 @@ let is_cancelled_inner w = w.cancelled
 
 let reset_cancelled_inner w = {w with cancelled = false}
 
-let value_inner w = List.nth w.items w.cursor
+(* Total: an out-of-range or stale cursor (e.g. after the underlying item
+   list shrinks) must not raise. [""] is the documented "no selection"
+   sentinel, matching the existing [get_selection] convention below. *)
+let value_inner w =
+  match List.nth_opt w.items w.cursor with Some v -> v | None -> ""
 
 let get_selection_inner w = value_inner w
 
@@ -265,6 +269,15 @@ let open_centered_sectioned ?cursor_label ?max_visible ~title ~sections
   let items = List.concat (List.map snd sections) in
   {title; items; to_string; inner; max_visible}
 
+(* Replace the item list in place. Deliberately does NOT reclamp the
+   cursor (unlike [open_centered]): if [items] is shorter than before, the
+   cursor may become stale (out of range for the new list). This is the
+   scenario the total accessors below ([get_selection], [value_opt],
+   [value]) exist to handle without raising. *)
+let set_items (w : 'a t) (items : 'a list) : 'a t =
+  let labels = List.map w.to_string items in
+  {w with items; inner = {w.inner with items = labels}}
+
 (* Size-aware rendering API. New callers may use [render_with_size]. *)
 let render_with_size
     ?(backend : Miaou_widgets_display.Widgets.backend =
@@ -326,15 +339,27 @@ let on_key (w : 'a t) ~key : 'a t * Miaou_interfaces.Key_event.result =
   (w', Miaou_interfaces.Key_event.of_bool handled)
 
 let get_selection (w : 'a t) : 'a option =
-  match w.items with [] -> None | _ -> Some (List.nth w.items w.inner.cursor)
+  (* Total: [List.nth_opt] guards against a stale cursor left over from a
+     shrunk item list instead of raising Invalid_argument. *)
+  List.nth_opt w.items w.inner.cursor
 
 let is_cancelled (w : 'a t) = w.inner.cancelled
 
 let reset_cancelled (w : 'a t) =
   {w with inner = {w.inner with cancelled = false}}
 
-(* Convenience: label string for current selection *)
-let value (w : 'a t) : string = List.nth w.inner.items w.inner.cursor
+(* Convenience: label string for current selection. Total: returns [""] for
+   an empty list or stale cursor (documented "no selection" sentinel,
+   consistent with [value_inner]/[get_selection] above). *)
+let value (w : 'a t) : string =
+  match List.nth_opt w.inner.items w.inner.cursor with
+  | Some v -> v
+  | None -> ""
+
+(* Total counterpart to [value]: returns [None] instead of the [""]
+   sentinel so callers can distinguish "no selection" unambiguously. *)
+let value_opt (w : 'a t) : string option =
+  List.nth_opt w.inner.items w.inner.cursor
 
 let () =
   Miaou_registry.register ~name:"select" ~mli:[%blob "select_widget.mli"] ()

--- a/src/miaou_widgets_input/select_widget.mli
+++ b/src/miaou_widgets_input/select_widget.mli
@@ -81,6 +81,19 @@ val open_centered_sectioned :
   unit ->
   'a t
 
+(** Replace the item list of an existing widget in place (e.g. for a
+    live-filtered candidate list), keeping the cursor position and other
+    state untouched.
+
+    Unlike {!open_centered}/{!open_centered_sectioned}, this does {b not}
+    reclamp the cursor to the new list's bounds: if [items] is shorter than
+    before, the cursor may become stale (no longer a valid index). Use
+    {!get_selection} or {!value_opt} afterwards — both are total and return
+    [None] rather than raising when the cursor no longer indexes a valid
+    item.
+*)
+val set_items : 'a t -> 'a list -> 'a t
+
 (** {1 Rendering} *)
 
 (** Render the select widget with size awareness.
@@ -156,8 +169,18 @@ val on_key : 'a t -> key:string -> 'a t * Miaou_interfaces.Key_event.result
 
     Returns [None] if the list is empty, [Some item] otherwise.
     The selected item is determined by the current cursor position.
+    Total: also returns [None] for a stale cursor left over from a
+    shrunk item list, instead of raising.
 *)
 val get_selection : 'a t -> 'a option
+
+(** Get the display label of the currently selected item.
+
+    Returns [None] if the list is empty or the cursor is stale (e.g. after
+    the underlying item list shrunk). Prefer this over relying on the
+    internal (non-mli) [""] sentinel used elsewhere in the module.
+*)
+val value_opt : 'a t -> string option
 
 (** Check if the user pressed Esc to cancel selection.
 

--- a/src/miaou_widgets_layout/file_browser_widget.ml
+++ b/src/miaou_widgets_layout/file_browser_widget.ml
@@ -9,29 +9,32 @@
 
 type entry = {name : string; is_dir : bool}
 
-(* Cache for directory listings and writable status to avoid repeated filesystem calls *)
-type cache = {
-  mutable cached_path : string;
-  mutable cached_entries : entry list;
-  mutable cached_writable : (string, bool) Hashtbl.t;
-  mutable cached_show_hidden : bool;
-}
+(* Cache for directory listings and writable status to avoid repeated
+   filesystem calls.
 
-let make_cache () =
-  {
-    cached_path = "";
-    cached_entries = [];
-    cached_writable = Hashtbl.create 32;
-    cached_show_hidden = false;
-  }
+   Historically this was a single mutable slot holding only the most
+   recently visited (path, show_hidden) pair, shared by every browser
+   instance in the process. Two [t] values browsing different directories
+   (or the same directory with different [dirs_only] filters) would
+   silently evict each other's cached listing, and public [invalidate_cache]
+   (used by tests and by "n"/mkdir flows) only ever cleared that single
+   slot.
 
-(* Global cache - invalidated when path changes *)
-let cache = make_cache ()
+   This keys the listing cache by [(path, dirs_only, show_hidden)] and the
+   writable cache by [path], so distinct browser instances/paths no longer
+   contaminate each other. [invalidate_cache] bumps a global epoch instead
+   of clearing tables directly: cache entries are tagged with the epoch
+   they were computed at, so every instance transparently refreshes on its
+   next access after invalidation, and [Hashtbl.replace] keeps memory bounded
+   by the number of distinct paths visited rather than growing per epoch. *)
+let cache_epoch = ref 0
 
-let invalidate_cache () =
-  cache.cached_path <- "" ;
-  cache.cached_entries <- [] ;
-  Hashtbl.clear cache.cached_writable
+let entries_cache : (string * bool * bool, int * entry list) Hashtbl.t =
+  Hashtbl.create 16
+
+let writable_cache : (string, int * bool) Hashtbl.t = Hashtbl.create 32
+
+let invalidate_cache () = incr cache_epoch
 
 type t = {
   current_path : string;
@@ -133,14 +136,14 @@ let open_centered ?(path = "/") ?(dirs_only = true) ?(require_writable = true)
 let clamp = List_nav.clamp
 
 let is_writable path =
-  match Hashtbl.find_opt cache.cached_writable path with
-  | Some v -> v
-  | None ->
+  match Hashtbl.find_opt writable_cache path with
+  | Some (epoch, v) when epoch = !cache_epoch -> v
+  | _ ->
       let sys = Miaou_interfaces.System.require () in
       let result =
         match sys.probe_writable ~path with Ok b -> b | Error _ -> false
       in
-      Hashtbl.add cache.cached_writable path result ;
+      Hashtbl.replace writable_cache path (!cache_epoch, result) ;
       result
 
 let rec next_available_name ~existing ~prefix idx =
@@ -184,30 +187,22 @@ let list_entries_safe path ~dirs_only ~show_hidden =
 
 let list_entries_with_parent path ~dirs_only ~show_hidden =
   (* Use cached entries if path and show_hidden match *)
-  if
-    cache.cached_path = path
-    && cache.cached_show_hidden = show_hidden
-    && cache.cached_entries <> []
-  then cache.cached_entries
-  else begin
-    (* Path or show_hidden changed - clear writable cache for fresh checks *)
-    if cache.cached_path <> path then Hashtbl.clear cache.cached_writable ;
-    let entries = list_entries_safe path ~dirs_only ~show_hidden in
-    let parent = Filename.dirname path in
-    let result =
-      let with_parent =
-        if parent = path then entries
-        else {name = ".."; is_dir = true} :: entries
+  let key = (path, dirs_only, show_hidden) in
+  match Hashtbl.find_opt entries_cache key with
+  | Some (epoch, entries) when epoch = !cache_epoch && entries <> [] -> entries
+  | _ ->
+      let entries = list_entries_safe path ~dirs_only ~show_hidden in
+      let parent = Filename.dirname path in
+      let result =
+        let with_parent =
+          if parent = path then entries
+          else {name = ".."; is_dir = true} :: entries
+        in
+        (* Always include the current directory entry first so Enter selects it by default. *)
+        {name = "."; is_dir = true} :: with_parent
       in
-      (* Always include the current directory entry first so Enter selects it by default. *)
-      {name = "."; is_dir = true} :: with_parent
-    in
-    (* Update cache *)
-    cache.cached_path <- path ;
-    cache.cached_entries <- result ;
-    cache.cached_show_hidden <- show_hidden ;
-    result
-  end
+      Hashtbl.replace entries_cache key (!cache_epoch, result) ;
+      result
 
 let is_cancelled w = w.cancelled
 
@@ -654,8 +649,13 @@ let render_with_size w ~focus:_ ~(size : LTerm_geom.size) =
     if len <= max_width then s
     else if max_width <= 1 then String.make max_width '.'
     else
-      let cut = max 0 (max_width - 1) in
-      String.sub s 0 cut ^ "."
+      (* Byte-safe cut: [String.sub s 0 (max_width - 1)] would slice a
+         multi-byte UTF-8 codepoint in half and produce an invalid string.
+         Use the canonical visible-width-to-byte-index helper instead. *)
+      let cut_bytes =
+        Helpers.visible_byte_index_of_pos s (max 0 (max_width - 1))
+      in
+      String.sub s 0 cut_bytes ^ "."
   in
   let pad_to_width s =
     let v = W.visible_chars_count s in

--- a/src/miaou_widgets_layout/grid_layout.ml
+++ b/src/miaou_widgets_layout/grid_layout.ml
@@ -139,8 +139,12 @@ let span_height row_sizes row_gap start count =
   !h + max 0 ((count - 1) * row_gap)
 
 let render t ~size =
-  let inner_w = size.LTerm_geom.cols - t.padding.left - t.padding.right in
-  let inner_h = size.LTerm_geom.rows - t.padding.top - t.padding.bottom in
+  let inner_w =
+    max 0 (size.LTerm_geom.cols - t.padding.left - t.padding.right)
+  in
+  let inner_h =
+    max 0 (size.LTerm_geom.rows - t.padding.top - t.padding.bottom)
+  in
   let n_rows = List.length t.rows in
   let n_cols = List.length t.cols in
   if n_rows = 0 || n_cols = 0 then ""
@@ -188,7 +192,12 @@ let render t ~size =
       rendered ;
     (* Assemble output line by line. *)
     let buf = Buffer.create (inner_w * inner_h) in
-    let left_pad = String.make t.padding.left ' ' in
+    (* [t.padding]/[t.col_gap]/[t.row_gap] are caller-supplied and not
+       validated at construction time; clamp with [max 0] at every
+       [String.make] use site (not just the already-clamped [inner_w]/
+       [inner_h] above) so a negative padding/gap value can't raise
+       Invalid_argument (crash-ub-fixes S1 sibling sweep). *)
+    let left_pad = String.make (max 0 t.padding.left) ' ' in
     let blank_line = String.make inner_w ' ' in
     (* Top padding *)
     for _ = 1 to t.padding.top do
@@ -212,7 +221,8 @@ let render t ~size =
         Buffer.add_string buf left_pad ;
         let col = ref 0 in
         while !col < n_cols do
-          if !col > 0 then Buffer.add_string buf (String.make t.col_gap ' ') ;
+          if !col > 0 then
+            Buffer.add_string buf (String.make (max 0 t.col_gap) ' ') ;
           match owner.(row).(!col) with
           | None ->
               Buffer.add_string buf (String.make col_sizes.(!col) ' ') ;

--- a/test/dune
+++ b/test/dune
@@ -143,7 +143,7 @@
 (test
  (name test_modal_renderer)
  (modules test_modal_renderer)
- (libraries alcotest miaou-core.internals))
+ (libraries alcotest astring miaou-core.internals))
 
 (test
  (name test_drivers_smoke)
@@ -250,6 +250,31 @@
  (name test_grid_layout)
  (modules test_grid_layout)
  (libraries alcotest miaou-core.widgets.layout miaou-core.widgets.display))
+
+(test
+ (name test_select_widget)
+ (modules test_select_widget)
+ (libraries alcotest miaou-core.widgets.input))
+
+(test
+ (name test_file_browser_cache)
+ (modules test_file_browser_cache)
+ (libraries alcotest astring miaou-core.widgets.layout miaou-core.interfaces))
+
+(test
+ (name test_headless_debug_gate)
+ (modules test_headless_debug_gate)
+ (libraries alcotest astring unix miaou-core.lib_miaou_internal))
+
+(test
+ (name test_matrix_driver_cleanup)
+ (modules test_matrix_driver_cleanup)
+ (libraries alcotest miaou-driver-matrix.driver))
+
+(test
+ (name test_service_lifecycle_adapter)
+ (modules test_service_lifecycle_adapter)
+ (libraries alcotest miaou-core.core miaou-core.interfaces))
 
 (test
  (name test_input_widgets)

--- a/test/test_drivers_smoke.ml
+++ b/test/test_drivers_smoke.ml
@@ -1,10 +1,12 @@
 open Alcotest
 
 let test_driver_flags () =
+  (* Miaou_runner_common.Tui_driver_common.size was a dead
+     [(Obj.magic 0 : t)] placeholder stub with no legitimate producer,
+     removed in crash-ub-fixes slice S8; nothing else referenced it. *)
   ignore Miaou_runner_common.Html_driver.available ;
   ignore Miaou_driver_term.Lambda_term_driver.available ;
-  ignore Miaou_driver_sdl.Sdl_enabled.enabled ;
-  ignore (Miaou_runner_common.Tui_driver_common.size ())
+  ignore Miaou_driver_sdl.Sdl_enabled.enabled
 
 let () =
   run

--- a/test/test_file_browser_cache.ml
+++ b/test/test_file_browser_cache.ml
@@ -1,0 +1,187 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Mathias Bourgoin <mathias.bourgoin@atacama.tech>        *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Regression tests for crash-ub-fixes slice S3:
+   - two [File_browser_widget.t] instances browsing different paths must not
+     contaminate each other's cached directory listing;
+   - entry-name truncation must stay valid UTF-8 (byte-safe cut) instead of
+     slicing a multi-byte codepoint in half. *)
+
+open Alcotest
+module FB = Miaou_widgets_layout.File_browser_widget
+
+let make_stub ~listing =
+  let open Miaou_interfaces in
+  let run_command ~argv:_ ~cwd:_ =
+    Ok System.{exit_code = 0; stdout = ""; stderr = ""}
+  in
+  System.
+    {
+      file_exists = (fun _ -> true);
+      is_directory = (fun _ -> true);
+      read_file = (fun _ -> Ok "");
+      write_file = (fun _ _ -> Ok ());
+      mkdir = (fun _ -> Ok ());
+      run_command;
+      get_current_user_info = (fun () -> Ok ("user", "/home/user"));
+      get_disk_usage = (fun ~path:_ -> Ok 0L);
+      list_dir = (fun path -> Ok (listing path));
+      probe_writable = (fun ~path:_ -> Ok true);
+      get_env_var = (fun _ -> None);
+    }
+
+(* A minimal UTF-8 validity check: no continuation byte (0x80-0xBF) may
+   appear without a preceding, still-open lead byte. *)
+let is_valid_utf8 s =
+  let len = String.length s in
+  let rec loop i =
+    if i >= len then true
+    else
+      let c = Char.code s.[i] in
+      if c < 0x80 then loop (i + 1)
+      else
+        let n_cont =
+          if c land 0xE0 = 0xC0 then 1
+          else if c land 0xF0 = 0xE0 then 2
+          else if c land 0xF8 = 0xF0 then 3
+          else -1
+        in
+        if n_cont < 0 || i + n_cont >= len then false
+        else
+          let rec check_cont k =
+            k > n_cont
+            ||
+            let cc = Char.code s.[i + k] in
+            cc land 0xC0 = 0x80 && check_cont (k + 1)
+          in
+          check_cont 1 && loop (i + n_cont + 1)
+  in
+  loop 0
+
+let test_two_instances_no_cross_contamination () =
+  let listing path =
+    if path = "/alpha" then ["alpha_one"; "alpha_two"]
+    else if path = "/beta" then ["beta_one"; "beta_two"]
+    else []
+  in
+  Miaou_interfaces.System.set (make_stub ~listing) ;
+  let a = FB.open_centered ~path:"/alpha" ~dirs_only:false () in
+  let b = FB.open_centered ~path:"/beta" ~dirs_only:false () in
+  let size = {LTerm_geom.rows = 20; cols = 40} in
+  (* Render b first so its listing is cached, then render a: a must still
+     see its own entries, not b's. *)
+  let out_b = FB.render_with_size b ~focus:true ~size in
+  let out_a = FB.render_with_size a ~focus:true ~size in
+  check bool "alpha sees its own entry" true (String.length out_a > 0) ;
+  check
+    bool
+    "alpha listing contains alpha_one"
+    true
+    (Astring.String.is_infix ~affix:"alpha_one" out_a) ;
+  check
+    bool
+    "alpha listing does not contain beta entries"
+    false
+    (Astring.String.is_infix ~affix:"beta_one" out_a) ;
+  check
+    bool
+    "beta listing contains beta_one"
+    true
+    (Astring.String.is_infix ~affix:"beta_one" out_b) ;
+  check
+    bool
+    "beta listing does not contain alpha entries"
+    false
+    (Astring.String.is_infix ~affix:"alpha_one" out_b)
+
+let test_invalidate_cache_refreshes_all_instances () =
+  let call_count = ref 0 in
+  let listing _path =
+    incr call_count ;
+    if !call_count <= 1 then ["before"] else ["after"]
+  in
+  Miaou_interfaces.System.set (make_stub ~listing) ;
+  let w = FB.open_centered ~path:"/gamma" ~dirs_only:false () in
+  let size = {LTerm_geom.rows = 20; cols = 40} in
+  let out1 = FB.render_with_size w ~focus:true ~size in
+  check
+    bool
+    "sees initial listing"
+    true
+    (Astring.String.is_infix ~affix:"before" out1) ;
+  FB.invalidate_cache () ;
+  let out2 = FB.render_with_size w ~focus:true ~size in
+  check
+    bool
+    "sees refreshed listing after invalidate_cache"
+    true
+    (Astring.String.is_infix ~affix:"after" out2)
+
+let test_same_path_different_dirs_only_no_contamination () =
+  (* The pre-fix cache keyed only on (path, show_hidden): a [dirs_only:true]
+     browser and a [dirs_only:false] browser at the *same* path would
+     silently share (and corrupt) each other's cached listing since
+     [dirs_only] filtering happens before caching. *)
+  let is_directory p = String.length p > 0 && p.[String.length p - 1] <> 't' in
+  Miaou_interfaces.System.set
+    {(make_stub ~listing:(fun _ -> ["a_dir"; "b_file.txt"])) with is_directory} ;
+  let dirs_only_w = FB.open_centered ~path:"/mixed" ~dirs_only:true () in
+  let all_w = FB.open_centered ~path:"/mixed" ~dirs_only:false () in
+  let size = {LTerm_geom.rows = 20; cols = 40} in
+  let out_dirs_only = FB.render_with_size dirs_only_w ~focus:true ~size in
+  let out_all = FB.render_with_size all_w ~focus:true ~size in
+  check
+    bool
+    "dirs_only listing excludes the file"
+    false
+    (Astring.String.is_infix ~affix:"b_file.txt" out_dirs_only) ;
+  check
+    bool
+    "unfiltered listing includes the file"
+    true
+    (Astring.String.is_infix ~affix:"b_file.txt" out_all)
+
+let test_multibyte_name_truncation_stays_valid_utf8 () =
+  (* Each CJK codepoint below is 3 bytes in UTF-8 and renders as width 2
+     (wide char), so a narrow column width forces a mid-name cut. *)
+  let long_name = String.concat "" (List.init 30 (fun _ -> "\xe6\x97\xa5")) in
+  (* "日" repeated *)
+  Miaou_interfaces.System.set (make_stub ~listing:(fun _ -> [long_name])) ;
+  let w = FB.open_centered ~path:"/utf8" ~dirs_only:false () in
+  let size = {LTerm_geom.rows = 20; cols = 15} in
+  let out = FB.render_with_size w ~focus:true ~size in
+  check
+    bool
+    "render does not raise and is non-empty"
+    true
+    (String.length out > 0) ;
+  check bool "output stays valid UTF-8" true (is_valid_utf8 out)
+
+let () =
+  run
+    "file_browser_cache"
+    [
+      ( "file_browser_cache",
+        [
+          test_case
+            "two instances no cross-contamination"
+            `Quick
+            test_two_instances_no_cross_contamination;
+          test_case
+            "invalidate_cache refreshes all instances"
+            `Quick
+            test_invalidate_cache_refreshes_all_instances;
+          test_case
+            "same path, different dirs_only, no contamination"
+            `Quick
+            test_same_path_different_dirs_only_no_contamination;
+          test_case
+            "multibyte name truncation stays valid UTF-8"
+            `Quick
+            test_multibyte_name_truncation_stays_valid_utf8;
+        ] );
+    ]

--- a/test/test_grid_layout.ml
+++ b/test/test_grid_layout.ml
@@ -181,6 +181,87 @@ let test_row_gap_multi_line () =
   check string "row 1 line 0" "BBBB" (List.nth lines 3) ;
   check string "row 1 line 1" "BBBB" (List.nth lines 4)
 
+(* Degenerate-size regression tests: padding/child geometry can make the
+   inner content area shrink to zero or below. Buffer.create/String.make
+   raise Invalid_argument on negative lengths, so render must clamp instead
+   of crashing (see crash-ub-fixes plan, slice S1). *)
+let test_zero_size () =
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 1]
+      ~cols:[Grid.Px 1]
+      [Grid.cell ~row:0 ~col:0 (fill_char 'A')]
+  in
+  (* Degenerate 0x0 container: previously `String.make inner_w ' '` with a
+     negative-derived inner_w could raise Invalid_argument; clamped to 0 it
+     must render without raising (fixed-size tracks still render at their
+     declared size, independent of the container). *)
+  let out = Grid.render grid ~size:(size 0 0) in
+  ignore out ;
+  check bool "no exception raised" true true
+
+let test_padding_exceeds_size () =
+  (* Padding larger than the available size drives inner_w/inner_h negative
+     before clamping; must not raise. *)
+  let padding : Miaou_widgets_layout.Flex_layout.padding =
+    {left = 5; right = 5; top = 5; bottom = 5}
+  in
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 1]
+      ~cols:[Grid.Px 1]
+      ~padding
+      [Grid.cell ~row:0 ~col:0 (fill_char 'A')]
+  in
+  let out = Grid.render grid ~size:(size 2 2) in
+  ignore out ;
+  check bool "no exception raised" true true
+
+let test_negative_padding_does_not_raise () =
+  (* Caller-supplied padding is not validated at construction; a negative
+     value must not reach String.make raw (reviewer-flagged sibling of the
+     inner_w/inner_h clamp: grid_layout.ml's left_pad). *)
+  let padding : Miaou_widgets_layout.Flex_layout.padding =
+    {left = -3; right = 0; top = 0; bottom = 0}
+  in
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 1]
+      ~cols:[Grid.Px 3]
+      ~padding
+      [Grid.cell ~row:0 ~col:0 (fill_char 'A')]
+  in
+  let out = Grid.render grid ~size:(size 10 1) in
+  ignore out ;
+  check bool "no exception raised" true true
+
+let test_negative_col_gap_does_not_raise () =
+  (* Same as above for [col_gap]: grid_layout.ml's per-column gap fill. *)
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 1]
+      ~cols:[Grid.Px 3; Grid.Px 3]
+      ~col_gap:(-2)
+      [
+        Grid.cell ~row:0 ~col:0 (fill_char 'A');
+        Grid.cell ~row:0 ~col:1 (fill_char 'B');
+      ]
+  in
+  let out = Grid.render grid ~size:(size 10 1) in
+  ignore out ;
+  check bool "no exception raised" true true
+
+let test_oversized_children () =
+  let grid =
+    Grid.create
+      ~rows:[Grid.Px 100]
+      ~cols:[Grid.Px 100]
+      [Grid.cell ~row:0 ~col:0 (fill_char 'A')]
+  in
+  let out = Grid.render grid ~size:(size 1 1) in
+  ignore out ;
+  check bool "no exception raised" true true
+
 let () =
   run
     "grid_layout"
@@ -198,5 +279,16 @@ let () =
           test_case "minmax track" `Quick test_minmax_track;
           test_case "row gap" `Quick test_row_gap;
           test_case "row gap multi-line" `Quick test_row_gap_multi_line;
+          test_case "zero size" `Quick test_zero_size;
+          test_case "padding exceeds size" `Quick test_padding_exceeds_size;
+          test_case
+            "negative padding does not raise"
+            `Quick
+            test_negative_padding_does_not_raise;
+          test_case
+            "negative col_gap does not raise"
+            `Quick
+            test_negative_col_gap_does_not_raise;
+          test_case "oversized children" `Quick test_oversized_children;
         ] );
     ]

--- a/test/test_headless_debug_gate.ml
+++ b/test/test_headless_debug_gate.ml
@@ -1,0 +1,131 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Mathias Bourgoin <mathias.bourgoin@atacama.tech>        *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Regression test for crash-ub-fixes slice S4: [Headless_driver]'s
+   "[driver][debug] ..." tracing must stay silent on stderr unless
+   MIAOU_DEBUG is set, instead of unconditionally firing on every
+   key/refresh iteration. *)
+
+open Alcotest
+module Headless = Lib_miaou_internal.Headless_driver
+
+module Page = struct
+  type state = int
+
+  type key_binding = state Miaou_core.Tui_page.key_binding_desc
+
+  type pstate = state Miaou_core.Navigation.t
+
+  type msg = unit
+
+  let maybe_quit ps =
+    if ps.Miaou_core.Navigation.s > 2 then Miaou_core.Navigation.quit ps else ps
+
+  let init () = Miaou_core.Navigation.make 0
+
+  let update ps _ = ps
+
+  let view ps ~focus:_ ~size:_ =
+    Printf.sprintf "st=%d" ps.Miaou_core.Navigation.s
+
+  let refresh ps =
+    Miaou_core.Navigation.update (fun st -> st + 1) ps |> maybe_quit
+
+  let move ps delta =
+    Miaou_core.Navigation.update (fun st -> st + delta) ps |> maybe_quit
+
+  let service_select ps _ = ps
+
+  let service_cycle ps _ = ps
+
+  let back ps = ps
+
+  let keymap _ = []
+
+  let handled_keys () = []
+
+  let handle_modal_key ps _ ~size:_ = ps
+
+  let handle_key ps key ~size:_ =
+    if key = "q" then ps
+    else
+      Miaou_core.Navigation.update (fun st -> st + String.length key) ps
+      |> maybe_quit
+
+  let on_key ps key ~size =
+    let key_str = Miaou_core.Keys.to_string key in
+    let ps' = handle_key ps key_str ~size in
+    (ps', Miaou_interfaces.Key_event.Bubble)
+
+  let on_modal_key ps key ~size =
+    let key_str = Miaou_core.Keys.to_string key in
+    let ps' = handle_modal_key ps key_str ~size in
+    (ps', Miaou_interfaces.Key_event.Bubble)
+
+  let key_hints _ = []
+
+  let has_modal _ = false
+end
+
+(* Redirect fd 2 (stderr) to a temp file for the duration of [f], then
+   return the captured content. *)
+let capture_stderr f =
+  Stdlib.flush Stdlib.stderr ;
+  let path = Filename.temp_file "miaou_headless_debug_gate" ".log" in
+  let saved_fd = Unix.dup Unix.stderr in
+  let out_fd = Unix.openfile path [Unix.O_WRONLY; Unix.O_TRUNC] 0o600 in
+  Unix.dup2 out_fd Unix.stderr ;
+  Unix.close out_fd ;
+  Fun.protect
+    ~finally:(fun () ->
+      Stdlib.flush Stdlib.stderr ;
+      Unix.dup2 saved_fd Unix.stderr ;
+      Unix.close saved_fd)
+    (fun () ->
+      f () ;
+      Stdlib.flush Stdlib.stderr) ;
+  let ic = open_in path in
+  let content = really_input_string ic (in_channel_length ic) in
+  close_in ic ;
+  Sys.remove path ;
+  content
+
+let test_no_debug_output_by_default () =
+  Unix.putenv "MIAOU_DEBUG" "" ;
+  let captured =
+    capture_stderr (fun () ->
+        Headless.set_limits ~iterations:5 ~seconds:5.0 () ;
+        Headless.feed_keys ["Down"; "Up"; "q"] ;
+        ignore
+          (Headless.run (module Page) : [`Quit | `Back | `SwitchTo of string]))
+  in
+  check
+    bool
+    "no [driver][debug] lines on stderr without MIAOU_DEBUG"
+    false
+    (Astring.String.is_infix ~affix:"[driver][debug]" captured)
+
+(* Note: [debug_enabled] is a [lazy] value (memoized after first force), by
+   design, matching the existing dprintf pattern elsewhere in the codebase
+   (e.g. Modal_manager, Modal_renderer). That makes an "enabled" companion
+   test order-dependent within a single test binary (whichever test forces
+   the lazy first wins for the rest of the process), so we only assert the
+   default (silent) behavior here, which is the crash/UB-relevant property:
+   headless test runs must not spew "[driver][debug]" on stderr by default. *)
+
+let () =
+  run
+    "headless_debug_gate"
+    [
+      ( "headless_debug_gate",
+        [
+          test_case
+            "no debug output by default"
+            `Quick
+            test_no_debug_output_by_default;
+        ] );
+    ]

--- a/test/test_matrix_driver_cleanup.ml
+++ b/test/test_matrix_driver_cleanup.ml
@@ -1,0 +1,84 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Mathias Bourgoin <mathias.bourgoin@atacama.tech>        *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Regression tests for crash-ub-fixes slice S6: [Matrix_driver] must run
+   terminal cleanup even when the main loop (a crashing page) raises, and
+   must re-raise the original exception with its backtrace intact rather
+   than losing it behind [Fun.protect]'s [Finally_raised]. These exercise
+   [run_with_cleanup] directly (headless — no real terminal/tty needed);
+   the end-to-end "terminal usable after crash" behavior is additionally
+   covered by the tmux scenario in test/tmux (best-effort, requires a real
+   terminal emulator). *)
+
+open Alcotest
+module Driver = Miaou_driver_matrix.Matrix_driver
+
+exception Boom of string
+
+let test_cleanup_runs_on_success () =
+  let cleanup_ran = ref false in
+  let result =
+    Driver.run_with_cleanup
+      ~cleanup:(fun () -> cleanup_ran := true)
+      (fun () -> 42)
+  in
+  check int "result returned" 42 result ;
+  check bool "cleanup ran" true !cleanup_ran
+
+let test_cleanup_runs_and_exception_reraised () =
+  let cleanup_ran = ref false in
+  let raised =
+    try
+      ignore
+        (Driver.run_with_cleanup
+           ~cleanup:(fun () -> cleanup_ran := true)
+           (fun () -> raise (Boom "page crashed"))) ;
+      None
+    with e -> Some e
+  in
+  check bool "cleanup ran despite exception" true !cleanup_ran ;
+  match raised with
+  | Some (Boom msg) ->
+      check string "original exception preserved" "page crashed" msg
+  | Some _ -> fail "wrong exception re-raised"
+  | None -> fail "expected exception to propagate"
+
+let test_cleanup_failure_does_not_hide_original_exception () =
+  (* A failing cleanup step must not mask the original exception (unlike
+     Fun.protect ~finally, which would wrap this in Finally_raised). *)
+  let raised =
+    try
+      ignore
+        (Driver.run_with_cleanup
+           ~cleanup:(fun () -> raise (Boom "cleanup itself failed"))
+           (fun () -> raise (Boom "original failure"))) ;
+      None
+    with e -> Some e
+  in
+  match raised with
+  | Some (Boom msg) ->
+      check string "original exception wins" "original failure" msg
+  | Some _ -> fail "wrong exception re-raised"
+  | None -> fail "expected exception to propagate"
+
+let () =
+  run
+    "matrix_driver_cleanup"
+    [
+      ( "matrix_driver_cleanup",
+        [
+          test_case "cleanup runs on success" `Quick test_cleanup_runs_on_success;
+          test_case
+            "cleanup runs and exception re-raised"
+            `Quick
+            test_cleanup_runs_and_exception_reraised;
+          test_case
+            "cleanup failure does not hide original exception"
+            `Quick
+            test_cleanup_failure_does_not_hide_original_exception;
+        ] );
+    ]

--- a/test/test_modal_manager.ml
+++ b/test/test_modal_manager.ml
@@ -116,10 +116,55 @@ let test_convenience () =
   check bool "helpers consumed" true (List.length !results = 3) ;
   check bool "stack empty" false (MM.has_active ())
 
+(* Regression test for crash-ub-fixes slice S10: document (and pin down)
+   the existing same-title replacement semantics — pushing a second frame
+   with the same title evicts the first WITHOUT invoking its [on_close].
+   This is intentional, existing behavior (see modal_manager.mli); the
+   test exists so that a future change to this semantics is a deliberate,
+   visible decision rather than an accidental regression. *)
+let test_same_title_eviction_skips_on_close () =
+  MM.clear () ;
+  let first_on_close_called = ref false in
+  let second_on_close_called = ref false in
+  MM.push
+    (module Modal_page)
+    ~init:(Modal_page.init ())
+    ~ui:{title = "dup"; left = None; max_width = None; dim_background = true}
+    ~commit_on:["ok"]
+    ~cancel_on:["Esc"]
+    ~on_close:(fun _ _ -> first_on_close_called := true) ;
+  check bool "first pushed" true (MM.has_active ()) ;
+  (* Push a second frame with the same title: the first is evicted
+     silently, its on_close must NOT fire. *)
+  MM.push
+    (module Modal_page)
+    ~init:(Modal_page.init ())
+    ~ui:{title = "dup"; left = None; max_width = None; dim_background = true}
+    ~commit_on:["ok"]
+    ~cancel_on:["Esc"]
+    ~on_close:(fun _ _ -> second_on_close_called := true) ;
+  check
+    bool
+    "first frame's on_close not invoked on eviction"
+    false
+    !first_on_close_called ;
+  check bool "still exactly one active modal" true (MM.has_active ()) ;
+  MM.handle_key "ok" ;
+  check
+    bool
+    "second frame's on_close invoked on its own commit"
+    true
+    !second_on_close_called ;
+  MM.clear ()
+
 let suite =
   [
     test_case "push/commit/cancel" `Quick test_push_commit_cancel;
     test_case "convenience helpers" `Quick test_convenience;
+    test_case
+      "same-title eviction skips on_close"
+      `Quick
+      test_same_title_eviction_skips_on_close;
   ]
 
 let () = run "modal_manager" [("modal_manager", suite)]

--- a/test/test_modal_renderer.ml
+++ b/test/test_modal_renderer.ml
@@ -103,11 +103,51 @@ let test_clamped_resize () =
         (size200.LTerm_geom.cols > size100.LTerm_geom.cols)
   | _ -> fail (Printf.sprintf "expected 3 sizes, got %d" (List.length !sizes))
 
+(* Regression test for crash-ub-fixes slice S5: [render_overlay] used to
+   force `dim_background || true`, so a caller asking for an undimmed
+   background (dim_background:false) was silently overridden and the base
+   was always dimmed (wrapped in the SGR "\027[2m...\027[0m" dim escape). *)
+let test_dim_background_false_leaves_base_undimmed () =
+  MS.set_provider (fun () ->
+      [("Modal", None, None, false, fun _size -> "content")]) ;
+  let base = "XXXXXXXXXX" in
+  let rendered = MR.render_overlay ~cols:(Some 20) ~rows:10 ~base () in
+  match rendered with
+  | None -> fail "expected overlay"
+  | Some s ->
+      check
+        bool
+        "undimmed background has no SGR dim escape"
+        false
+        (Astring.String.is_infix ~affix:"\027[2m" s)
+
+let test_dim_background_true_dims_base () =
+  MS.set_provider (fun () ->
+      [("Modal", None, None, true, fun _size -> "content")]) ;
+  let base = "XXXXXXXXXX" in
+  let rendered = MR.render_overlay ~cols:(Some 20) ~rows:10 ~base () in
+  match rendered with
+  | None -> fail "expected overlay"
+  | Some s ->
+      check
+        bool
+        "dimmed background contains SGR dim escape"
+        true
+        (Astring.String.is_infix ~affix:"\027[2m" s)
+
 let suite =
   [
     test_case "render overlay" `Quick test_overlay;
     test_case "dynamic resize" `Quick test_dynamic_resize;
     test_case "clamped resize" `Quick test_clamped_resize;
+    test_case
+      "dim_background:false leaves base undimmed"
+      `Quick
+      test_dim_background_false_leaves_base_undimmed;
+    test_case
+      "dim_background:true dims base"
+      `Quick
+      test_dim_background_true_dims_base;
   ]
 
 let () = run "modal_renderer" [("modal_renderer", suite)]

--- a/test/test_select_widget.ml
+++ b/test/test_select_widget.ml
@@ -1,0 +1,131 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Mathias Bourgoin <mathias.bourgoin@atacama.tech>        *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Regression tests for crash-ub-fixes slice S2: [Select_widget]'s cursor
+   accessors must be total (no exception) for empty item lists and stale
+   cursor positions, instead of raising via [List.nth]. *)
+
+open Alcotest
+module Select = Miaou_widgets_input.Select_widget
+
+let test_get_selection_empty () =
+  let w =
+    Select.open_centered ~title:"t" ~items:[] ~to_string:(fun s -> s) ()
+  in
+  check bool "no selection on empty list" true (Select.get_selection w = None)
+
+let test_value_opt_empty () =
+  let w =
+    Select.open_centered ~title:"t" ~items:[] ~to_string:(fun s -> s) ()
+  in
+  check bool "value_opt is None on empty list" true (Select.value_opt w = None)
+
+let test_get_selection_populated () =
+  let w =
+    Select.open_centered
+      ~title:"t"
+      ~items:["a"; "b"; "c"]
+      ~to_string:(fun s -> s)
+      ()
+  in
+  check
+    (option string)
+    "first item selected"
+    (Some "a")
+    (Select.get_selection w)
+
+let test_value_opt_populated () =
+  let w =
+    Select.open_centered
+      ~title:"t"
+      ~items:["a"; "b"; "c"]
+      ~to_string:(fun s -> s)
+      ()
+  in
+  check
+    (option string)
+    "value_opt returns label"
+    (Some "a")
+    (Select.value_opt w)
+
+let test_end_key_at_last_index () =
+  (* Regression: End moves cursor to the last valid index; get_selection
+     must not raise even with the maximal cursor value. *)
+  let w =
+    Select.open_centered
+      ~title:"t"
+      ~items:["a"; "b"; "c"]
+      ~to_string:(fun s -> s)
+      ()
+  in
+  let w = Select.handle_key w ~key:"End" in
+  check (option string) "last item selected" (Some "c") (Select.get_selection w)
+
+let test_stale_cursor_after_list_shrinks () =
+  (* The actual defect class named in the crash-ub-fixes plan: drive the
+     cursor to the end of a populated list, then shrink the item list
+     in place (via [set_items], which deliberately does not reclamp the
+     cursor) so the cursor is now stale (out of range for the new,
+     shorter list). [get_selection]/[value_opt] must report "no
+     selection" (None) rather than raising via List.nth. *)
+  let w =
+    Select.open_centered
+      ~title:"t"
+      ~items:["a"; "b"; "c"; "d"; "e"]
+      ~to_string:(fun s -> s)
+      ()
+  in
+  let w = Select.handle_key w ~key:"End" in
+  check
+    (option string)
+    "cursor at last index before shrinking"
+    (Some "e")
+    (Select.get_selection w) ;
+  (* Shrink from 5 items to 2: the cursor (now pointing at index 4) is
+     stale for the new list. *)
+  let w = Select.set_items w ["x"; "y"] in
+  check
+    (option string)
+    "get_selection is None for a stale cursor (no exception)"
+    None
+    (Select.get_selection w) ;
+  check
+    bool
+    "value_opt is None for a stale cursor (no exception)"
+    true
+    (Select.value_opt w = None) ;
+  (* Home brings the cursor back in range; selection resumes normally.
+     [handle_key] doesn't reclamp automatically for set_items (only for
+     Up/Down/Home/End movement), so an explicit Home confirms the widget
+     recovers once the cursor is valid again rather than staying wedged. *)
+  let w = Select.handle_key w ~key:"Home" in
+  check
+    (option string)
+    "selection resumes once cursor is back in range"
+    (Some "x")
+    (Select.get_selection w)
+
+let () =
+  run
+    "select_widget"
+    [
+      ( "select_widget",
+        [
+          test_case "get_selection empty" `Quick test_get_selection_empty;
+          test_case "value_opt empty" `Quick test_value_opt_empty;
+          test_case
+            "get_selection populated"
+            `Quick
+            test_get_selection_populated;
+          test_case "value_opt populated" `Quick test_value_opt_populated;
+          test_case "End key at last index" `Quick test_end_key_at_last_index;
+          test_case
+            "stale cursor after list shrinks via set_items"
+            `Quick
+            test_stale_cursor_after_list_shrinks;
+        ] );
+    ]

--- a/test/test_service_lifecycle_adapter.ml
+++ b/test/test_service_lifecycle_adapter.ml
@@ -1,0 +1,186 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Mathias Bourgoin <mathias.bourgoin@atacama.tech>        *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Regression test for crash-ub-fixes slice S9: [Miaou_core.Service_lifecycle]
+   used to share its capability key with [Miaou_interfaces.Service_lifecycle]
+   via [Obj.magic], and on the interface-fallback path additionally
+   [Obj.magic]-cast an interface value straight into the core module's [t] —
+   despite the two [t]s having different closure shapes (different status
+   variant representation, and [remove_instance_files] with vs. without
+   [~role]). This registers an implementation only via the interface module
+   (as an external "Systemd_service_lifecycle"-style adapter would), fetches
+   it through core's [require], and exercises every method to prove the
+   explicit adapter round-trips correctly instead of reinterpreting bytes. *)
+
+open Alcotest
+module Iface = Miaou_interfaces.Service_lifecycle
+module Core = Miaou_core.Service_lifecycle
+
+let make_mock_iface () =
+  let calls = ref [] in
+  let record name = calls := name :: !calls in
+  let iv =
+    Iface.create
+      ~start:(fun ~role ~service ->
+        record (Printf.sprintf "start:%s:%s" role service) ;
+        Ok ())
+      ~stop:(fun ~role ~service ->
+        record (Printf.sprintf "stop:%s:%s" role service) ;
+        Ok ())
+      ~restart:(fun ~role ~service ->
+        record (Printf.sprintf "restart:%s:%s" role service) ;
+        Ok ())
+      ~status:(fun ~role ~service ->
+        record (Printf.sprintf "status:%s:%s" role service) ;
+        if service = "failing" then Ok (`Failed "boom")
+        else if service = "down" then Ok `Inactive
+        else Ok `Active)
+      ~install_unit:(fun ~role ~app_bin_dir:_ ~user ->
+        record (Printf.sprintf "install_unit:%s:%s" role user) ;
+        Ok ())
+      ~write_dropin_node:(fun ~inst ~data_dir ~app_bin_dir:_ ->
+        record (Printf.sprintf "write_dropin_node:%s:%s" inst data_dir) ;
+        Ok ())
+      ~enable_start:(fun ~role ~inst ->
+        record (Printf.sprintf "enable_start:%s:%s" role inst) ;
+        Ok ())
+      ~enable:(fun ~role ~inst ->
+        record (Printf.sprintf "enable:%s:%s" role inst) ;
+        Ok ())
+      ~disable:(fun ~role ~inst ->
+        record (Printf.sprintf "disable:%s:%s" role inst) ;
+        Ok ())
+      ~remove_instance_files:(fun ~inst ~remove_data ->
+        (* Deliberately no [~role] here: the interface is role-agnostic. *)
+        record (Printf.sprintf "remove_instance_files:%s:%b" inst remove_data) ;
+        Ok ())
+  in
+  (iv, calls)
+
+let with_clean_capability f =
+  Miaou_interfaces.Capability.clear () ;
+  Fun.protect ~finally:Miaou_interfaces.Capability.clear f
+
+let test_adapter_roundtrips_all_methods () =
+  with_clean_capability (fun () ->
+      let iv, calls = make_mock_iface () in
+      Iface.register iv ;
+      let v = Core.require () in
+      check
+        (result unit string)
+        "start"
+        (Ok ())
+        (Core.start v ~role:"node" ~service:"svc") ;
+      check
+        (result unit string)
+        "stop"
+        (Ok ())
+        (Core.stop v ~role:"node" ~service:"svc") ;
+      check
+        (result unit string)
+        "restart"
+        (Ok ())
+        (Core.restart v ~role:"node" ~service:"svc") ;
+      check
+        (result unit string)
+        "install_unit"
+        (Ok ())
+        (Core.install_unit v ~role:"node" ~app_bin_dir:None ~user:"u") ;
+      check
+        (result unit string)
+        "write_dropin_node"
+        (Ok ())
+        (Core.write_dropin_node v ~inst:"i1" ~data_dir:"/d" ~app_bin_dir:None) ;
+      check
+        (result unit string)
+        "enable_start"
+        (Ok ())
+        (Core.enable_start v ~role:"node" ~inst:"i1") ;
+      check
+        (result unit string)
+        "enable"
+        (Ok ())
+        (Core.enable v ~role:"node" ~inst:"i1") ;
+      check
+        (result unit string)
+        "disable"
+        (Ok ())
+        (Core.disable v ~role:"node" ~inst:"i1") ;
+      (* remove_instance_files: core's signature carries ~role, the
+         interface's does not — the adapter must drop it, not corrupt the
+         call (the pre-fix Obj.magic cast would call through the wrong
+         closure arity here). *)
+      check
+        (result unit string)
+        "remove_instance_files"
+        (Ok ())
+        (Core.remove_instance_files v ~role:"node" ~inst:"i1" ~remove_data:true) ;
+      check
+        bool
+        "remove_instance_files call reached the mock with the right args (role \
+         dropped)"
+        true
+        (List.mem "remove_instance_files:i1:true" !calls))
+
+let test_status_variant_translation () =
+  with_clean_capability (fun () ->
+      let iv, _calls = make_mock_iface () in
+      Iface.register iv ;
+      let v = Core.require () in
+      check
+        (result
+           (of_pp (fun fmt -> function
+             | Core.Running -> Format.fprintf fmt "Running"
+             | Core.Stopped -> Format.fprintf fmt "Stopped"
+             | Core.Failed m -> Format.fprintf fmt "Failed %s" m))
+           string)
+        "Active -> Running"
+        (Ok Core.Running)
+        (Core.get_status v ~role:"node" ~service:"up") ;
+      check
+        (result
+           (of_pp (fun fmt -> function
+             | Core.Running -> Format.fprintf fmt "Running"
+             | Core.Stopped -> Format.fprintf fmt "Stopped"
+             | Core.Failed m -> Format.fprintf fmt "Failed %s" m))
+           string)
+        "Inactive -> Stopped"
+        (Ok Core.Stopped)
+        (Core.get_status v ~role:"node" ~service:"down") ;
+      match Core.get_status v ~role:"node" ~service:"failing" with
+      | Ok (Core.Failed msg) ->
+          check string "Failed message preserved" "boom" msg
+      | Ok _ -> fail "expected Failed"
+      | Error _ -> fail "expected Ok (Failed _)")
+
+let test_fallback_stub_when_nothing_registered () =
+  with_clean_capability (fun () ->
+      let v = Core.require () in
+      match Core.start v ~role:"r" ~service:"s" with
+      | Error _ -> ()
+      | Ok () -> fail "expected fallback stub to report unavailability")
+
+let () =
+  run
+    "service_lifecycle_adapter"
+    [
+      ( "service_lifecycle_adapter",
+        [
+          test_case
+            "adapter roundtrips all methods"
+            `Quick
+            test_adapter_roundtrips_all_methods;
+          test_case
+            "status variant translation"
+            `Quick
+            test_status_variant_translation;
+          test_case
+            "fallback stub when nothing registered"
+            `Quick
+            test_fallback_stub_when_nothing_registered;
+        ] );
+    ]

--- a/test/tmux/lib.sh
+++ b/test/tmux/lib.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Minimal tmux harness for MIAOU runtime scenarios (crash-ub-fixes slice S0).
+#
+# Not wired into `dune runtest`: tmux availability in CI/sandbox is not
+# guaranteed, and these scenarios exercise real terminal/signal behavior
+# that alcotest cannot observe (raw mode, SIGTERM delivery, stty state).
+# Run scenario scripts directly, e.g.:
+#
+#   bash test/tmux/scenario_sigterm.sh
+#
+# Each scenario sources this file, then:
+#   1. tmux_new_session <name> <cmd...>
+#   2. tmux_send_keys / tmux_capture_pane / assertions
+#   3. tmux_kill_session <name>   (also happens automatically via the EXIT
+#      trap installed by tmux_new_session, so scenarios are safe to `exit`
+#      early on assertion failure without leaking sessions)
+#
+# All functions print one-line PASS/FAIL-style diagnostics; scenarios
+# should `exit 1` on the first failed assertion.
+
+set -u
+
+TMUX_HARNESS_SESSIONS=()
+
+tmux_cleanup_all() {
+  local s
+  for s in "${TMUX_HARNESS_SESSIONS[@]:-}"; do
+    [ -z "$s" ] && continue
+    tmux kill-session -t "$s" >/dev/null 2>&1 || true
+  done
+}
+trap tmux_cleanup_all EXIT
+
+# tmux_new_session <session_name> <cols> <rows> <command...>
+tmux_new_session() {
+  local name="$1" cols="$2" rows="$3"
+  shift 3
+  tmux new-session -d -s "$name" -x "$cols" -y "$rows" "$@"
+  TMUX_HARNESS_SESSIONS+=("$name")
+}
+
+# tmux_send_keys <session_name> <keys...>
+tmux_send_keys() {
+  local name="$1"
+  shift
+  tmux send-keys -t "$name" "$@"
+}
+
+# tmux_capture_pane <session_name> -> prints pane content to stdout
+tmux_capture_pane() {
+  local name="$1"
+  tmux capture-pane -p -t "$name"
+}
+
+# tmux_pane_pid <session_name> -> prints the PID of the pane's process
+tmux_pane_pid() {
+  local name="$1"
+  tmux list-panes -t "$name" -F '#{pane_pid}'
+}
+
+# tmux_session_exists <session_name> -> exit 0 if alive, 1 if gone
+tmux_session_exists() {
+  tmux has-session -t "$1" >/dev/null 2>&1
+}
+
+# tmux_wait_gone <session_name> <timeout_seconds> -> exit 0 if the session
+# (and its process tree) disappeared within the timeout, 1 otherwise.
+tmux_wait_gone() {
+  local name="$1" timeout="$2" waited=0
+  while tmux_session_exists "$name"; do
+    sleep 0.1
+    waited=$(awk -v w="$waited" 'BEGIN { print w + 0.1 }')
+    if awk -v w="$waited" -v t="$timeout" 'BEGIN { exit !(w >= t) }'; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+tmux_kill_session() {
+  local name="$1"
+  tmux kill-session -t "$name" >/dev/null 2>&1 || true
+}

--- a/test/tmux/scenario_sigterm.sh
+++ b/test/tmux/scenario_sigterm.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# S7 regression scenario: an idle Matrix-driver TUI must react to SIGTERM
+# promptly (the self-pipe wake-up fixes a liveness gap where the input
+# reader fiber could stay parked in a blocking await with no incoming
+# keystrokes to unblock it), exit with the conventional 130 code, and
+# leave the terminal in a sane state (no leftover raw mode / alt-screen /
+# mouse tracking, i.e. `stty` reports sane settings for the pane's tty
+# after the process is gone).
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+source test/tmux/lib.sh
+
+BIN="_build/default/example/gallery/main_matrix.exe"
+if [ ! -x "$BIN" ]; then
+  echo "SKIP: $BIN not built (run: dune build example/gallery/main_matrix.exe)"
+  exit 0
+fi
+
+SESSION="miaou_sigterm_$$"
+# Wrap in `sh -c '... ; echo EXIT:$?'` so the exit code survives past the
+# process replacing the shell, and is visible in the captured pane.
+tmux_new_session "$SESSION" 80 24 sh -c "$BIN; echo EXIT:\$?"
+sleep 1.0
+
+if ! tmux_session_exists "$SESSION"; then
+  echo "FAIL: session exited before SIGTERM was sent"
+  exit 1
+fi
+
+pid="$(tmux_pane_pid "$SESSION")"
+if [ -z "$pid" ]; then
+  echo "FAIL: could not determine pane PID"
+  tmux_kill_session "$SESSION"
+  exit 1
+fi
+
+# Target the whole process group so the signal reaches the actual
+# main_matrix.exe process (a child of the `sh -c` wrapper), not just the
+# shell wrapper.
+start_s=$(date +%s.%N)
+kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
+
+if tmux_wait_gone "$SESSION" 2; then
+  end_s=$(date +%s.%N)
+  elapsed=$(awk -v a="$start_s" -v b="$end_s" 'BEGIN { printf "%.2f", b - a }')
+  echo "PASS: session terminated ${elapsed}s after SIGTERM (bound: 2s)"
+else
+  echo "FAIL: session still alive 2s after SIGTERM (idle-TUI liveness regression)"
+  tmux_kill_session "$SESSION"
+  exit 1
+fi
+
+# The pane is gone, but tmux buffers the last screen; the wrapper's
+# `echo EXIT:$?` line (captured just before the pane closed, if tmux kept
+# history) is best-effort evidence of the exit code. Not all tmux/pty
+# configurations retain this after the session closes, so treat it as
+# informational rather than a hard assertion.
+echo "INFO: expected exit code 130 (SIGTERM); direct capture after session close is best-effort and not asserted here."
+
+echo "SIGTERM SCENARIO OK"

--- a/test/tmux/scenario_smoke.sh
+++ b/test/tmux/scenario_smoke.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# S0 smoke scenario: the Matrix-driver demo starts, renders something, and
+# responds to a quit key inside a real tmux pty. Establishes that the
+# harness (test/tmux/lib.sh) works end-to-end before relying on it for the
+# S6/S7 crash/signal scenarios.
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+source test/tmux/lib.sh
+
+BIN="_build/default/example/gallery/main_matrix.exe"
+if [ ! -x "$BIN" ]; then
+  echo "SKIP: $BIN not built (run: dune build example/gallery/main_matrix.exe)"
+  exit 0
+fi
+
+SESSION="miaou_smoke_$$"
+tmux_new_session "$SESSION" 80 24 "$BIN"
+sleep 1.0
+
+if ! tmux_session_exists "$SESSION"; then
+  echo "FAIL: session exited before we could interact with it"
+  exit 1
+fi
+
+pane="$(tmux_capture_pane "$SESSION")"
+if [ -z "$pane" ]; then
+  echo "FAIL: pane content is empty after 1s"
+  exit 1
+fi
+echo "PASS: pane rendered non-empty content"
+
+tmux_send_keys "$SESSION" "q"
+if tmux_wait_gone "$SESSION" 3; then
+  echo "PASS: quit key terminated the session within 3s"
+else
+  echo "FAIL: session still alive 3s after quit key"
+  tmux_kill_session "$SESSION"
+  exit 1
+fi
+
+echo "SMOKE OK"


### PR DESCRIPTION
## Summary
Fixes the crash/UB findings of the 2026-07-15 whole-tree audit (`briefs/audit-2026-07-15.md` findings 2–6, 9–15): memory-unsafe capability cast, terminal left corrupted on page exceptions, signal-handler deadlock path, two widget crash classes (+ sibling sweep), forced modal dimming, headless stderr spam, file-browser cache contamination and UTF-8 truncation corruption, dead `Obj.magic` stubs. 35 files, +1649/−141, every fix with its regression test; first tmux scenario harness included (`test/tmux/`).

Deliberately deferred to the structural-debt package (documented in-code and in `kb/risks.md`): modal on_close-on-eviction semantics (D7) and the load-bearing `exit 0` in `tui_driver_common` (D11) — both need design work (unique frame ids / real fiber cancellation).

## Pipeline evidence
- Plan: dual-voice consensus (`briefs/crash-ub-fixes-plan.md`) — 11 defects verified, 3 re-scoped with recorded reasons
- Review: 3 medium + 2 low findings fixed and re-verified (async-signal-safe escape hatch via `Unix._exit`, stale-cursor regression test, sibling clamps)
- QA: PASS — build/runtest/fmt green, tmux SIGTERM scenario exits 0.00s with code 130, interactive gallery smoke captured, no Obj.magic outside comments, test count 76 files (+5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)