### PR TITLE
fix(mcp): gate miaou-mcp behind MIAOU_MCP so CI build stays green

### DIFF
--- a/src/miaou_mcp/dune
+++ b/src/miaou_mcp/dune
@@ -8,13 +8,20 @@
 ;   opam install mcp-kit mcp-kit-eio
 ;   dune build src/miaou_mcp
 ; `(optional)` means `dune build @all`/`dune runtest` silently skip these
-; targets when the pin is absent, so the rest of the tree stays green.
+; targets when the pin is absent — but `(optional)` alone is NOT enough:
+; `dune build @all` (which CI runs) forces optional targets and hard-fails
+; when mcp-kit is absent. `(enabled_if MIAOU_MCP=1)` removes these stanzas
+; from the build graph entirely unless a developer opts in, so CI (which
+; never sets it) is always green. Build locally with `MIAOU_MCP=1 dune
+; build src/miaou_mcp` after adding the pin above.
 ; Promote to a real opam package once mcp-kit is published. See
 ; docs/agent-protocol.md "Root-build story".
 
 (library
  (name mcp_tools)
  (modules mcp_tools)
+ (enabled_if
+  (= %{env:MIAOU_MCP=} 1))
  (optional)
  (instrumentation
   (backend bisect_ppx))
@@ -25,6 +32,8 @@
 (executable
  (name miaou_mcp_main)
  (modules miaou_mcp_main)
+ (enabled_if
+  (= %{env:MIAOU_MCP=} 1))
  (optional)
  (instrumentation
   (backend bisect_ppx))

--- a/test/mcp/dune
+++ b/test/mcp/dune
@@ -1,13 +1,15 @@
-; Optional for the same reason src/miaou_mcp/dune is: mcp-kit is only
-; present in a switch that has pinned the commit named in
-; the pin (see src/miaou_mcp/dune). `(test)` doesn't support `(optional)`
-; directly, so this is spelled out as an `(executable)` (which does) plus a
-; manual `runtest` alias rule; `dune runtest` silently skips this suite
-; instead of failing when that pin is absent.
+; Gated behind MIAOU_MCP=1 for the same reason as src/miaou_mcp/dune:
+; mcp-kit is only present when the pin is added, and `(optional)` alone
+; doesn't stop `dune build @all` / an explicit rule dependency from forcing
+; the build. `(enabled_if MIAOU_MCP=1)` on both the executable and the
+; runtest rule removes them from the graph entirely unless opted in, so CI
+; stays green. Run locally with `MIAOU_MCP=1 dune runtest test/mcp`.
 
 (executable
  (name mcp_tools_test)
  (modules mcp_tools_test)
+ (enabled_if
+  (= %{env:MIAOU_MCP=} 1))
  (optional)
  (libraries
   alcotest
@@ -22,6 +24,8 @@
 
 (rule
  (alias runtest)
+ (enabled_if
+  (= %{env:MIAOU_MCP=} 1))
  (deps mcp_tools_test.exe)
  (action
   (run %{deps})))


### PR DESCRIPTION
## Summary
Hotfix: main went red after #165 because `(optional)` doesn't stop `dune build @all` (which CI runs) from forcing the optional mcp targets, so the absent `mcp-kit` library hard-failed the build. Gates the miaou-mcp library, executable, test, and its runtest rule behind `(enabled_if MIAOU_MCP=1)`.

Verified locally: gate off (CI's exact condition, even with the pin installed) → `dune build @all` + `dune runtest` green, mcp binary not built, MCP tmux scenario SKIPs; gate on (`MIAOU_MCP=1`) → the server binary still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)